### PR TITLE
Refactor: Replace PostgreSQL with DuckDB, parallelize API calls, and …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
     "loguru>=0.7.3",
-    "psycopg2-binary>=2.9.10",
+    "duckdb>=0.10.0",
     "pydantic>=2.11.4",
     "sqlalchemy>=2.0.41",
     "tenacity>=9.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
+    "duckdb>=1.3.0",
     "httpx>=0.28.1",
     "loguru>=0.7.3",
-    "duckdb>=0.10.0",
     "pydantic>=2.11.4",
     "sqlalchemy>=2.0.41",
     "tenacity>=9.1.2",

--- a/src/sejm_scraper/api_client.py
+++ b/src/sejm_scraper/api_client.py
@@ -11,64 +11,56 @@ retry_settings = {
 
 
 @retry(**retry_settings)
-def get_terms(client: httpx.Client) -> list[schemas.TermSchema]:
-    result = (
-        client.get("https://api.sejm.gov.pl/sejm/term", timeout=30)
-        .raise_for_status()
-        .json()
-    )
+async def get_terms(client: httpx.AsyncClient) -> list[schemas.TermSchema]:
+    response = await client.get("https://api.sejm.gov.pl/sejm/term", timeout=30)
+    response.raise_for_status()
+    result = response.json()
     return [schemas.TermSchema(**item) for item in result]
 
 
 @retry(**retry_settings)
-def get_sittings(
-    client: httpx.Client, term: int
+async def get_sittings(
+    client: httpx.AsyncClient, term: int
 ) -> list[schemas.SittingSchema]:
-    result = (
-        client.get(
-            f"https://api.sejm.gov.pl/sejm/term{term}/proceedings", timeout=30
-        )
-        .raise_for_status()
-        .json()
+    response = await client.get(
+        f"https://api.sejm.gov.pl/sejm/term{term}/proceedings", timeout=30
     )
+    response.raise_for_status()
+    result = response.json()
     return [schemas.SittingSchema(**item) for item in result]
 
 
 @retry(**retry_settings)
-def get_votings(
-    client: httpx.Client, term: int, sitting: int
+async def get_votings(
+    client: httpx.AsyncClient, term: int, sitting: int
 ) -> list[schemas.VotingSchema]:
-    result = (
-        client.get(
-            f"https://api.sejm.gov.pl/sejm/term{term}/votings/{sitting}",
-            timeout=30,
-        )
-        .raise_for_status()
-        .json()
+    response = await client.get(
+        f"https://api.sejm.gov.pl/sejm/term{term}/votings/{sitting}",
+        timeout=30,
     )
+    response.raise_for_status()
+    result = response.json()
     return [schemas.VotingSchema(**item) for item in result]
 
 
 @retry(**retry_settings)
-def get_votes(
-    client: httpx.Client, term: int, sitting: int, voting: int
+async def get_votes(
+    client: httpx.AsyncClient, term: int, sitting: int, voting: int
 ) -> schemas.VotingWithMpVotesSchema:
-    result = (
-        client.get(
-            f"https://api.sejm.gov.pl/sejm/term{term}/votings/{sitting}/{voting}",
-            timeout=30,
-        )
-        .raise_for_status()
-        .json()
+    response = await client.get(
+        f"https://api.sejm.gov.pl/sejm/term{term}/votings/{sitting}/{voting}",
+        timeout=30,
     )
+    response.raise_for_status()
+    result = response.json()
     return schemas.VotingWithMpVotesSchema(**result)
 
 
 @retry(**retry_settings)
-def get_mps(client: httpx.Client, term: int) -> list[schemas.MpSchema]:
-    result = (
-        client.get(f"https://api.sejm.gov.pl/sejm/term{term}/MP", timeout=30)
-        .raise_for_status()
-        .json()
+async def get_mps(client: httpx.AsyncClient, term: int) -> list[schemas.MpSchema]:
+    response = await client.get(
+        f"https://api.sejm.gov.pl/sejm/term{term}/MP", timeout=30
     )
+    response.raise_for_status()
+    result = response.json()
     return [schemas.MpSchema(**item) for item in result]

--- a/src/sejm_scraper/database.py
+++ b/src/sejm_scraper/database.py
@@ -1,5 +1,5 @@
-import os
-
+import duckdb
+import os  # Added import
 from sqlalchemy import (
     CHAR,
     Column,
@@ -8,23 +8,106 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
-    create_engine,
 )
-from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy.orm import declarative_base, relationship
 
-database_name = os.getenv("SEJM_SCRAPER_DATABASE", "postgres")
-user = os.getenv("SEJM_SCRAPER_USER", "postgres")
-password = os.getenv("SEJM_SCRAPER_PASSWORD", "postgres")
-host = os.getenv("SEJM_SCRAPER_HOST", "localhost")
-port = os.getenv("SEJM_SCRAPER_PORT", "5432")
+# DUCKDB_FILE is now initialized from an environment variable, with a default.
+DUCKDB_FILE = os.getenv("SEJM_SCRAPER_DUCKDB_FILE", "sejm_scraper.duckdb")
 
-engine = create_engine(
-    f"postgresql://{user}:{password}@{host}:{port}/{database_name}",
-)
-
-SessionMaker = sessionmaker(bind=engine)
+def get_duckdb_connection():
+    # This function will now use the potentially overridden DUCKDB_FILE
+    return duckdb.connect(DUCKDB_FILE, read_only=False)
 
 Base = declarative_base()
+
+def create_tables_if_not_exists(conn):
+    """
+    Creates tables in the DuckDB database based on the SQLAlchemy models
+    if they do not already exist.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Terms (
+            id VARCHAR PRIMARY KEY,
+            number INTEGER NOT NULL,
+            from_date DATE NOT NULL,
+            to_date DATE
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Sittings (
+            id VARCHAR PRIMARY KEY,
+            term_id VARCHAR NOT NULL REFERENCES Terms(id),
+            title VARCHAR NOT NULL,
+            number INTEGER NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Votings (
+            id VARCHAR PRIMARY KEY,
+            sitting_id VARCHAR NOT NULL REFERENCES Sittings(id),
+            sitting_day INTEGER NOT NULL,
+            number INTEGER NOT NULL,
+            date TIMESTAMP NOT NULL,
+            title VARCHAR NOT NULL,
+            description VARCHAR,
+            topic VARCHAR
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS VotingOptions (
+            id VARCHAR PRIMARY KEY,
+            voting_id VARCHAR NOT NULL REFERENCES Votings(id),
+            index INTEGER NOT NULL,
+            description VARCHAR
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS MPs (
+            id VARCHAR PRIMARY KEY,
+            first_name VARCHAR NOT NULL,
+            second_name VARCHAR,
+            last_name VARCHAR NOT NULL,
+            birth_date DATE NOT NULL,
+            birth_place VARCHAR
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Votes (
+            id VARCHAR PRIMARY KEY,
+            voting_option_id VARCHAR NOT NULL REFERENCES VotingOptions(id),
+            mp_id VARCHAR NOT NULL REFERENCES MPs(id),
+            vote VARCHAR NOT NULL,
+            party VARCHAR
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS MpToTermLink (
+            id VARCHAR PRIMARY KEY,
+            mp_id VARCHAR NOT NULL REFERENCES MPs(id),
+            term_id VARCHAR NOT NULL REFERENCES Terms(id),
+            in_term_id INTEGER NOT NULL,
+            education VARCHAR,
+            profession VARCHAR,
+            voivodeship VARCHAR,
+            district_name VARCHAR NOT NULL,
+            inactivity_cause VARCHAR,
+            inactivity_description VARCHAR
+        );
+        """
+    )
 
 
 class Terms(Base):

--- a/src/sejm_scraper/main.py
+++ b/src/sejm_scraper/main.py
@@ -1,215 +1,364 @@
-from typing import Annotated, Union
+import asyncio
+import itertools
+import os # Added import
+from typing import Annotated, Union, Optional, List, Any, Dict
 
 import httpx
 import typer
 from loguru import logger
 
 from sejm_scraper import api_client as api
-from sejm_scraper import process, schemas
-from sejm_scraper.database import (
-    Base,
-    SessionMaker,
-    Sittings,
-    Terms,
-    Votings,
-    engine,
-)
+from sejm_scraper import process, schemas, utils, database # Modified import
+from sejm_scraper.database import get_duckdb_connection, create_tables_if_not_exists
+
 
 app = typer.Typer()
+
+@app.callback()
+def main_callback(
+    ctx: typer.Context,
+    db_path: Annotated[Optional[str], typer.Option(
+        help="Path to the DuckDB database file. Overrides SEJM_SCRAPER_DUCKDB_FILE env var.",
+        envvar="SEJM_SCRAPER_DUCKDB_FILE", # Typer can also read from env var, but we give CLI precedence
+    )] = None,
+):
+    """
+    Manage Sejm Scraper.
+    The database path can be set using the --db-path option or the SEJM_SCRAPER_DUCKDB_FILE environment variable.
+    CLI option takes precedence.
+    """
+    # database.DUCKDB_FILE is initialized in database.py using os.getenv
+    # If db_path is provided via CLI, it overrides any value (from env var or default)
+    if db_path:
+        database.DUCKDB_FILE = db_path
+        logger.info(f"Using DuckDB database file (from --db-path): {database.DUCKDB_FILE}")
+    elif "SEJM_SCRAPER_DUCKDB_FILE" in os.environ:
+        # If --db-path is not used, but env var is set, database.py already handled it.
+        # We log it here for clarity.
+        logger.info(f"Using DuckDB database file (from SEJM_SCRAPER_DUCKDB_FILE): {database.DUCKDB_FILE}")
+    else:
+        # If neither --db-path nor env var is set, the default from database.py is used.
+        logger.info(f"Using default DuckDB database file: {database.DUCKDB_FILE}")
 
 
 @app.command()
 def prepare_database() -> None:
-    Base.metadata.create_all(engine)
+    logger.info("Preparing database...")
+    conn = None
+    try:
+        conn = get_duckdb_connection()
+        create_tables_if_not_exists(conn)
+        logger.info("Database prepared successfully.")
+    except Exception as e:
+        logger.error(f"Error preparing database: {e}")
+    finally:
+        if conn:
+            conn.close()
+
+
+async def _fetch_and_process_votings_for_sittings(
+    client: httpx.AsyncClient,
+    term_schema: schemas.TermSchema,
+    sittings_batch: List[schemas.SittingSchema],
+    conn: Any, # DuckDB connection
+    mp_id_lookup: Dict[int, str], # in_term_id -> mp_id for the current term
+    chunk_size: int,
+    semaphore: asyncio.Semaphore,
+    from_voting_num: Optional[int],
+):
+    processed_votings_data = []
+    processed_voting_options_data = []
+    processed_votes_data = []
+
+    voting_api_tasks = []
+    sitting_map = {} # To map task result back to sitting
+
+    for sitting_schema in sittings_batch:
+        # Apply from_voting filter at the sitting level if applicable
+        # This means we might fetch votings for a sitting even if only some are needed
+        # More granular filtering is done after fetching.
+        task = asyncio.ensure_future(
+            api.get_votings(client, term_schema.number, sitting_schema.number)
+        )
+        voting_api_tasks.append(task)
+        sitting_map[task] = sitting_schema # Associate task with its sitting
+
+    # Gather votings for the batch of sittings
+    votings_results_for_sittings_batch = []
+    for i in range(0, len(voting_api_tasks), int(semaphore_value)): # Respect semaphore for gather
+        tasks_chunk = voting_api_tasks[i:i+int(semaphore_value)]
+        async with semaphore: # Ensure overall concurrency control
+             votings_results_for_sittings_batch.extend(await asyncio.gather(*tasks_chunk))
+
+
+    votes_api_tasks = []
+    voting_map = {} # To map task result back to (term, sitting, voting)
+
+    for i, raw_votings_for_sitting_list in enumerate(votings_results_for_sittings_batch):
+        sitting_schema = sitting_map[voting_api_tasks[i]] # Retrieve corresponding sitting
+
+        current_votings_to_process = raw_votings_for_sitting_list
+        if from_voting_num is not None and term_schema.number == current_from_term_num and sitting_schema.number == current_from_sitting_num:
+            current_votings_to_process = [v for v in current_votings_to_process if v.number >= from_voting_num]
+        
+        if not current_votings_to_process:
+            logger.info(f"No votings to process for sitting {sitting_schema.number} in term {term_schema.number} after filtering.")
+            continue
+
+        for voting_schema in current_votings_to_process:
+            processed_votings_data.append(
+                process.process_voting(voting_schema, term_schema, sitting_schema)
+            )
+            
+            # Voting Options
+            current_voting_options = voting_schema.voting_options
+            if current_voting_options is None:
+                current_voting_options = [schemas.VotingOptionSchema(optionIndex=1, description=None)]
+            
+            for vo_schema in current_voting_options:
+                processed_voting_options_data.append(
+                    process.process_voting_option(vo_schema, term_schema, sitting_schema, voting_schema)
+                )
+
+            # Prepare to fetch votes for this voting
+            task = asyncio.ensure_future(
+                api.get_votes(client, term_schema.number, sitting_schema.number, voting_schema.number)
+            )
+            votes_api_tasks.append(task)
+            voting_map[task] = (term_schema, sitting_schema, voting_schema)
+
+    # Gather all votes for all relevant votings
+    all_raw_votes_data = []
+    for i in range(0, len(votes_api_tasks), int(semaphore_value)): # Respect semaphore
+        tasks_chunk = votes_api_tasks[i:i+int(semaphore_value)]
+        async with semaphore: # Ensure overall concurrency control
+            all_raw_votes_data.extend(await asyncio.gather(*tasks_chunk))
+
+    for i, raw_votes_schema in enumerate(all_raw_votes_data): # schemas.VotingWithMpVotesSchema
+        term_s, sitting_s, voting_s = voting_map[votes_api_tasks[i]] # Retrieve context
+        if not raw_votes_schema.mp_votes:
+            logger.warning(f"No MP votes data for term {term_s.number}, sitting {sitting_s.number}, voting {voting_s.number}")
+            continue
+        for mp_vote_schema in raw_votes_schema.mp_votes:
+            mp_id = mp_id_lookup.get(mp_vote_schema.mp_term_id)
+            if mp_id is None:
+                logger.error(
+                    f"Could not find mp_id for mp_term_id {mp_vote_schema.mp_term_id} "
+                    f"in term {term_s.number}. Skipping vote."
+                )
+                continue
+            
+            vote_records = process.process_vote(
+                term_s, sitting_s, voting_s, mp_vote_schema, mp_id
+            )
+            processed_votes_data.extend(vote_records)
+
+    # Bulk insert collected data for this batch of sittings
+    if processed_votings_data:
+        process.bulk_insert_data(conn, "Votings", processed_votings_data, process.VOTINGS_COLUMN_ORDER, chunk_size)
+    if processed_voting_options_data:
+        process.bulk_insert_data(conn, "VotingOptions", processed_voting_options_data, process.VOTING_OPTIONS_COLUMN_ORDER, chunk_size)
+    if processed_votes_data:
+        process.bulk_insert_data(conn, "Votes", processed_votes_data, process.VOTES_COLUMN_ORDER, chunk_size)
+
+
+# Store from_point details globally for access in helper functions if needed, or pass them down.
+# For simplicity here, making them global within the module for scrape.
+# A class-based approach or passing context object would be cleaner for larger apps.
+current_from_term_num: Optional[int] = None
+current_from_sitting_num: Optional[int] = None
+current_from_voting_num: Optional[int] = None
+semaphore_value: int = 10 # Default, will be updated by scrape function parameter
 
 
 @app.command()
-def scrape(
+async def scrape(
     from_point: Annotated[
         Union[str, None],
         typer.Option(
             help="In form of term[,sitting[,voting]], e.g. 10,13,35; 10,13; 10"
         ),
     ] = None,
+    parallelism_limit: Annotated[int, typer.Option(help="Max concurrent API calls.")] = 10,
+    chunk_size: Annotated[int, typer.Option(help="Rows per bulk insert chunk.")] = 100,
 ) -> None:
-    from_term, from_sitting, from_voting = None, None, None
+    global current_from_term_num, current_from_sitting_num, current_from_voting_num, semaphore_value
+    semaphore_value = parallelism_limit
+    semaphore = asyncio.Semaphore(parallelism_limit)
+
     if from_point is not None:
         from_elements = [int(x) for x in from_point.split(",")]
         fill = 3 - len(from_elements)
-        from_term, from_sitting, from_voting = from_elements + [None] * fill
+        parsed_from_elements = from_elements + [None] * fill
+        current_from_term_num, current_from_sitting_num, current_from_voting_num = parsed_from_elements
+        logger.info(f"Starting scrape from: Term={current_from_term_num}, Sitting={current_from_sitting_num}, Voting={current_from_voting_num}")
+    else:
+        current_from_term_num, current_from_sitting_num, current_from_voting_num = None, None, None
+        logger.info("Starting scrape from the beginning.")
 
-    client = httpx.Client(timeout=30.0)
+    client = httpx.AsyncClient(timeout=30.0)
+    conn = get_duckdb_connection()
 
-    #
-    # terms
-    #
+    try:
+        # TERMS (Processed sequentially as there aren't many)
+        logger.info("Fetching terms...")
+        raw_terms = await api.get_terms(client)
+        if not raw_terms:
+            logger.warning("No terms data found.")
+            return
 
-    terms = api.get_terms(client)
-    if not terms:
-        logger.warning("No terms data")
-    if from_term is not None:
-        terms = [term for term in terms if term.number >= from_term]
-    for term in terms:
-        process.process_term(term=term)
+        terms_to_process = raw_terms
+        if current_from_term_num is not None:
+            terms_to_process = [term for term in terms_to_process if term.number >= current_from_term_num]
+        
+        if not terms_to_process:
+            logger.info("No terms to process after filtering by from_point.")
+            return
 
-        #
-        # mps
-        #
+        processed_terms_data = [process.process_term(t) for t in terms_to_process]
+        process.bulk_insert_data(conn, "Terms", processed_terms_data, process.TERMS_COLUMN_ORDER, chunk_size)
+        logger.info(f"Processed and inserted {len(processed_terms_data)} terms.")
 
-        mps = api.get_mps(client, term.number)
-        if not mps:
-            logger.warning(f"No MPs data for term {term.number}")
-        for mp in mps:
-            process.process_mp(mp=mp, term=term)
-            process.process_mp_to_term_link(mp=mp, term=term)
+        for term_schema in terms_to_process:
+            term_id = utils.get_term_nk(term_schema)
+            logger.info(f"Processing term {term_schema.number} (ID: {term_id})...")
 
-        #
-        # sittings
-        #
+            # MPs for the current term
+            logger.info(f"Fetching MPs for term {term_schema.number}...")
+            async with semaphore: # Limit concurrency for get_mps
+                raw_mps = await api.get_mps(client, term_schema.number)
+            if not raw_mps:
+                logger.warning(f"No MPs data for term {term_schema.number}")
+            else:
+                processed_mps_data = [process.process_mp(mp) for mp in raw_mps] # Pass term_schema if needed by process_mp
+                processed_mp_links_data = [process.process_mp_to_term_link(mp, term_schema) for mp in raw_mps]
+                process.bulk_insert_data(conn, "MPs", processed_mps_data, process.MPS_COLUMN_ORDER, chunk_size)
+                process.bulk_insert_data(conn, "MpToTermLink", processed_mp_links_data, process.MP_TO_TERM_LINK_COLUMN_ORDER, chunk_size)
+                logger.info(f"Processed and inserted {len(processed_mps_data)} MPs and links for term {term_schema.number}.")
 
-        sittings = api.get_sittings(client, term.number)
-        if not sittings:
-            logger.warning(f"No sittings data for term {term.number}")
+            # Create mp_id_lookup for this term (in_term_id -> mp_id)
+            mp_id_lookup_rows = conn.execute(
+                f"SELECT in_term_id, mp_id FROM MpToTermLink WHERE term_id = ?", (term_id,)
+            ).fetchall()
+            mp_id_lookup = {row[0]: row[1] for row in mp_id_lookup_rows}
+            logger.debug(f"Created mp_id_lookup for term {term_schema.number} with {len(mp_id_lookup)} entries.")
 
-        if from_sitting is not None and term.number == from_term:
-            # note that this also filters out planned meetings
-            # (all have number: 0) hence no skip log from
-            # the process_sitting
-            sittings = [
-                sitting
-                for sitting in sittings
-                if sitting.number >= from_sitting
-            ]
-        for sitting in sittings:
-            process.process_sitting(sitting=sitting, term=term)
+            # SITTINGS for the current term
+            logger.info(f"Fetching sittings for term {term_schema.number}...")
+            async with semaphore: # Limit concurrency for get_sittings
+                 raw_sittings_for_term = await api.get_sittings(client, term_schema.number)
+            
+            if not raw_sittings_for_term:
+                logger.warning(f"No sittings data for term {term_schema.number}")
+                continue
 
-            #
-            # votings
-            #
+            sittings_to_process = [s for s in raw_sittings_for_term if s.number != 0] # Exclude planned sittings
+            if current_from_sitting_num is not None and term_schema.number == current_from_term_num:
+                sittings_to_process = [s for s in sittings_to_process if s.number >= current_from_sitting_num]
 
-            votings = api.get_votings(client, term.number, sitting.number)
-            if not votings:
-                logger.warning(
-                    f"No voting data for term {term.number}, "
-                    f"sitting {sitting.number}"
-                )
-            if (
-                from_voting is not None
-                and sitting.number == from_sitting
-                and term.number == from_term
-            ):
-                votings = [
-                    voting for voting in votings if voting.number >= from_voting
-                ]
-            for voting in votings:
-                process.process_voting(
-                    voting=voting, term=term, sitting=sitting
-                )
+            if not sittings_to_process:
+                logger.info(f"No sittings to process for term {term_schema.number} after filtering.")
+                continue
+                
+            processed_sittings_data = [process.process_sitting(s, term_schema) for s in sittings_to_process if s is not None]
+            # Filter out None results if process_sitting can return None (it does for planned sittings, already filtered)
+            processed_sittings_data = [s_data for s_data in processed_sittings_data if s_data is not None]
 
-                #
-                # voting options
-                #
+            if processed_sittings_data:
+                 process.bulk_insert_data(conn, "Sittings", processed_sittings_data, process.SITTINGS_COLUMN_ORDER, chunk_size)
+                 logger.info(f"Processed and inserted {len(processed_sittings_data)} sittings for term {term_schema.number}.")
+            
+            # VOTINGS and VOTES (Processed in batches of sittings)
+            # The _fetch_and_process_votings_for_sittings handles its own parallelism for API calls via semaphore
+            # and accumulates data for votings, voting_options, and votes.
+            # It then bulk inserts them.
+            # We pass the sittings_to_process (which are schema objects)
+            
+            # The helper function will now handle fetching votings, then votes, and processing them.
+            # It needs the list of sitting *schema objects* to iterate over.
+            await _fetch_and_process_votings_for_sittings(
+                client,
+                term_schema,
+                sittings_to_process, # Pass the filtered list of sitting schema objects
+                conn,
+                mp_id_lookup,
+                chunk_size,
+                semaphore, # Pass the original semaphore for it to manage sub-tasks
+                current_from_voting_num if term_schema.number == current_from_term_num and current_from_sitting_num is not None else None,
+            )
+            
+            # Reset from_sitting and from_voting after the first applicable term is processed
+            if term_schema.number == current_from_term_num:
+                current_from_sitting_num = None
+                current_from_voting_num = None
 
-                voting_options = voting.voting_options
-                if voting_options is None:
-                    # provide "default" option
-                    voting_options = [
-                        schemas.VotingOptionSchema(
-                            **{"optionIndex": 1, "description": None}
-                        )
-                    ]
-                for voting_option in voting_options:
-                    process.process_voting_option(
-                        voting_option=voting_option,
-                        term=term,
-                        sitting=sitting,
-                        voting=voting,
-                    )
-                #
-                # votes
-                #
 
-                votes = api.get_votes(
-                    client, term.number, sitting.number, voting.number
-                )
-                if not votings:
-                    logger.warning(
-                        f"No votes data for term {term.number} ",
-                        f"sitting {sitting.number}, voting {voting.number}",
-                    )
-                for vote in votes.mp_votes:
-                    process.process_vote(
-                        term=term,
-                        sitting=sitting,
-                        voting=voting,
-                        vote=vote,
-                    )
+        logger.info("Scraping finished.")
 
-    logger.info("All done")
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP error occurred: {e.request.url} - {e.response.status_code} - {e.response.text}")
+    except Exception as e:
+        logger.opt(exception=True).error(f"An unexpected error occurred during scraping: {e}")
+    finally:
+        await client.aclose()
+        if conn:
+            conn.close()
+        logger.info("Client and database connection closed.")
 
 
 @app.command()
-def resume() -> None:
-    with SessionMaker() as db:
-        latest_term = (
-            db.query(Terms.number).order_by(Terms.number.desc()).first()
-        )
+async def resume(
+    parallelism_limit: Annotated[int, typer.Option(help="Max concurrent API calls.")] = 10,
+    chunk_size: Annotated[int, typer.Option(help="Rows per bulk insert chunk.")] = 100,
+) -> None:
+    logger.info("Attempting to resume scraping...")
+    conn = get_duckdb_connection()
+    from_point_str: Optional[str] = None
 
-        if latest_term is None:
-            logger.info("No existing data found. Starting from the beginning")
-            scrape()
+    try:
+        latest_term_row = conn.execute("SELECT MAX(number) FROM Terms").fetchone()
+        if latest_term_row is None or latest_term_row[0] is None:
+            logger.info("No existing data found. Starting full scrape.")
+            await scrape(from_point=None, parallelism_limit=parallelism_limit, chunk_size=chunk_size)
             return
 
-        latest_term_number = latest_term[0]
+        latest_term_number = latest_term_row[0]
 
-        latest_sitting = (
-            db.query(Sittings.number)
-            .join(Terms)
-            .filter(Terms.number == latest_term_number)
-            .order_by(Sittings.number.desc())
-            .first()
-        )
+        latest_sitting_row = conn.execute(
+            "SELECT MAX(S.number) FROM Sittings S JOIN Terms T ON S.term_id = T.id WHERE T.number = ?",
+            (latest_term_number,)
+        ).fetchone()
 
-        if latest_sitting is None:
-            from_point = f"{latest_term_number}"
-            logger.info(f"Resuming from term {latest_term_number}")
-            scrape(from_point=from_point)
-            return
+        if latest_sitting_row is None or latest_sitting_row[0] is None:
+            from_point_str = f"{latest_term_number}"
+            logger.info(f"Resuming from term {latest_term_number}.")
+        else:
+            latest_sitting_number = latest_sitting_row[0]
+            latest_voting_row = conn.execute(
+                """
+                SELECT MAX(V.number) 
+                FROM Votings V
+                JOIN Sittings S ON V.sitting_id = S.id
+                JOIN Terms T ON S.term_id = T.id
+                WHERE T.number = ? AND S.number = ?
+                """, (latest_term_number, latest_sitting_number)
+            ).fetchone()
 
-        latest_sitting_number = latest_sitting[0]
+            if latest_voting_row is None or latest_voting_row[0] is None:
+                from_point_str = f"{latest_term_number},{latest_sitting_number}"
+                logger.info(f"Resuming from term {latest_term_number}, sitting {latest_sitting_number}.")
+            else:
+                latest_voting_number = latest_voting_row[0]
+                from_point_str = f"{latest_term_number},{latest_sitting_number},{latest_voting_number}"
+                logger.info(f"Resuming from term {latest_term_number}, sitting {latest_sitting_number}, voting {latest_voting_number}.")
+        
+        await scrape(from_point=from_point_str, parallelism_limit=parallelism_limit, chunk_size=chunk_size)
 
-        latest_voting = (
-            db.query(Votings.number)
-            .join(Sittings)
-            .join(Terms)
-            .filter(
-                Terms.number == latest_term_number,
-                Sittings.number == latest_sitting_number,
-            )
-            .order_by(Votings.number.desc())
-            .first()
-        )
-
-        if latest_voting is None:
-            from_point = f"{latest_term_number},{latest_sitting_number}"
-            logger.info(
-                f"Resuming from term {latest_term_number}, "
-                f"sitting {latest_sitting_number}"
-            )
-            scrape(from_point=from_point)
-            return
-
-        latest_voting_number = latest_voting[0]
-
-        from_point = (
-            f"{latest_term_number},{latest_sitting_number},"
-            f"{latest_voting_number}"
-        )
-        logger.info(
-            f"Resuming from term {latest_term_number}, "
-            f"sitting {latest_sitting_number}, voting {latest_voting_number}"
-        )
-        scrape(from_point=from_point)
+    except Exception as e:
+        logger.opt(exception=True).error(f"Error during resume operation: {e}")
+    finally:
+        if conn:
+            conn.close()
 
 
 if __name__ == "__main__":

--- a/src/sejm_scraper/process.py
+++ b/src/sejm_scraper/process.py
@@ -1,73 +1,149 @@
+from typing import Any, Dict, List, Optional
+
 from loguru import logger
 
-from sejm_scraper import database, schemas, utils
-from sejm_scraper.database import SessionMaker
+from sejm_scraper import schemas, utils
+
+
+# Column orders for executemany
+# These must match the CREATE TABLE statements in database.py
+# and the keys in the dictionaries returned by process_* functions.
+TERMS_COLUMN_ORDER = ["id", "number", "from_date", "to_date"]
+SITTINGS_COLUMN_ORDER = ["id", "term_id", "title", "number"]
+VOTINGS_COLUMN_ORDER = [
+    "id",
+    "sitting_id",
+    "sitting_day",
+    "number",
+    "date",
+    "title",
+    "description",
+    "topic",
+]
+VOTING_OPTIONS_COLUMN_ORDER = ["id", "voting_id", "index", "description"]
+MPS_COLUMN_ORDER = [
+    "id",
+    "first_name",
+    "second_name",
+    "last_name",
+    "birth_date",
+    "birth_place",
+]
+VOTES_COLUMN_ORDER = ["id", "voting_option_id", "mp_id", "vote", "party"]
+MP_TO_TERM_LINK_COLUMN_ORDER = [
+    "id",
+    "mp_id",
+    "term_id",
+    "in_term_id",
+    "education",
+    "profession",
+    "voivodeship",
+    "district_name",
+    "inactivity_cause",
+    "inactivity_description",
+]
+
+
+def bulk_insert_data(
+    conn: Any,  # duckdb connection object
+    table_name: str,
+    data: List[Dict[str, Any]],
+    column_order: List[str],
+    chunk_size: int = 100,
+) -> None:
+    if not data:
+        return
+
+    logger.info(f"Bulk inserting {len(data)} rows into {table_name}")
+    
+    # Convert list of dicts to list of tuples, ensuring correct column order
+    tuples_to_insert = []
+    for row_dict in data:
+        try:
+            tuples_to_insert.append(tuple(row_dict[col] for col in column_order))
+        except KeyError as e:
+            logger.error(f"Missing key {e} in row: {row_dict} for table {table_name}")
+            # Potentially skip row or raise error, for now logging and skipping problematic part
+            # To be safe, we'll skip the whole chunk if one row is bad to avoid partial inserts
+            # or data corruption due to misaligned columns.
+            logger.error(f"Skipping chunk for {table_name} due to data error.")
+            return
+
+
+    if not tuples_to_insert:
+        logger.warning(f"No valid data to insert into {table_name} after validation.")
+        return
+
+    placeholders = ", ".join(["?"] * len(column_order))
+    insert_query = f"INSERT INTO {table_name} ({', '.join(column_order)}) VALUES ({placeholders})"
+
+    for i in range(0, len(tuples_to_insert), chunk_size):
+        chunk = tuples_to_insert[i : i + chunk_size]
+        try:
+            conn.executemany(insert_query, chunk)
+            logger.debug(f"Inserted chunk of {len(chunk)} rows into {table_name}")
+        except Exception as e:
+            logger.error(f"Error inserting chunk into {table_name}: {e}")
+            # Depending on the error, might want to retry or handle specific exceptions
+    logger.info(f"Finished bulk inserting into {table_name}")
 
 
 def process_term(
     term: schemas.TermSchema,
-) -> None:
+) -> Dict[str, Any]:
     logger.info(f"Processing {term.number} term")
     term_id = utils.get_term_nk(term=term)
-    db_item = database.Terms(
-        id=term_id,
-        number=term.number,
-        from_date=term.from_date,
-        to_date=term.to_date,
-    )
-    with SessionMaker() as db:
-        db.merge(db_item)
-        db.commit()
+    return {
+        "id": term_id,
+        "number": term.number,
+        "from_date": term.from_date,
+        "to_date": term.to_date,
+    }
 
 
 def process_sitting(
     sitting: schemas.SittingSchema,
     term: schemas.TermSchema,
-) -> None:
+) -> Optional[Dict[str, Any]]:
     logger.info(f"Processing sitting {sitting.number} in {term.number} term")
-    term_id = utils.get_term_nk(term)
-    if sitting.number != 0:  # skip planned sittings
-        sitting_id = utils.get_sitting_nk(sitting=sitting, term=term)
-        db_item = database.Sittings(
-            id=sitting_id,
-            term_id=term_id,
-            title=sitting.title,
-            number=sitting.number,
-        )
-        with SessionMaker() as db:
-            db.merge(db_item)
-            db.commit()
-    else:
+    if sitting.number == 0:  # skip planned sittings
         logger.info(
             f"Sitting {sitting.number} in {term.number} "
             "term is planned sitting, skipping"
         )
+        return None
+
+    term_id = utils.get_term_nk(term)
+    sitting_id = utils.get_sitting_nk(sitting=sitting, term=term)
+    return {
+        "id": sitting_id,
+        "term_id": term_id,
+        "title": sitting.title,
+        "number": sitting.number,
+    }
 
 
 def process_voting(
     voting: schemas.VotingSchema,
     term: schemas.TermSchema,
     sitting: schemas.SittingSchema,
-) -> None:
+) -> Dict[str, Any]:
     logger.info(
         f"Processing voting {voting.number} in sitting {sitting.number} "
         f"in {term.number} term"
     )
     voting_id = utils.get_voting_nk(voting=voting, term=term, sitting=sitting)
     sitting_id = utils.get_sitting_nk(sitting=sitting, term=term)
-    db_item = database.Votings(
-        id=voting_id,
-        sitting_id=sitting_id,
-        sitting_day=voting.sitting_day,
-        number=voting.number,
-        date=voting.date,
-        title=voting.title,
-        description=voting.description,
-        topic=voting.topic,
-    )
-    with SessionMaker() as db:
-        db.merge(db_item)
-        db.commit()
+    return {
+        "id": voting_id,
+        "sitting_id": sitting_id,
+        "sitting_day": voting.sitting_day,
+        "number": voting.number,
+        "date": voting.date,
+        "title": voting.title,
+        "description": voting.description,
+        "topic": voting.topic,
+    }
 
 
 def process_voting_option(
@@ -75,7 +151,7 @@ def process_voting_option(
     term: schemas.TermSchema,
     sitting: schemas.SittingSchema,
     voting: schemas.VotingSchema,
-) -> None:
+) -> Dict[str, Any]:
     logger.info(
         f"Processing voting option {voting_option.index} "
         f"in voting {voting.number} "
@@ -88,15 +164,12 @@ def process_voting_option(
         sitting=sitting,
         voting=voting,
     )
-    db_item = database.VotingOptions(
-        id=voting_option_id,
-        voting_id=voting_id,
-        index=voting_option.index,
-        description=voting_option.description,
-    )
-    with SessionMaker() as db:
-        db.merge(db_item)
-        db.commit()
+    return {
+        "id": voting_option_id,
+        "voting_id": voting_id,
+        "index": voting_option.index,
+        "description": voting_option.description,
+    }
 
 
 def process_vote(
@@ -104,107 +177,94 @@ def process_vote(
     sitting: schemas.SittingSchema,
     voting: schemas.VotingSchema,
     vote: schemas.MpVoteSchema,
-) -> None:
-    term_id = utils.get_term_nk(term)
+    mp_id: str,  # mp_id is now passed as an argument
+) -> List[Dict[str, Any]]:
+    processed_votes = []
 
-    with SessionMaker() as db:
-        mp_id_query = (
-            db.query(database.MpToTermLink)
-            .filter(
-                database.MpToTermLink.term_id == term_id,
-                database.MpToTermLink.in_term_id == vote.mp_term_id,
+    inner_votes = vote.votes
+    if inner_votes is None:
+        if vote.vote == "VOTE_VALID":
+            # This case was raising TypeError, indicates an invalid state.
+            # Log an error and skip this vote record.
+            logger.error(
+                f"Invalid vote data: 'votes' is None but 'vote' is 'VOTE_VALID'. "
+                f"MP Term ID: {vote.mp_term_id}, Voting: {voting.number}, "
+                f"Sitting: {sitting.number}, Term: {term.number}"
             )
-            .first()
+            return [] # Return empty list for this invalid vote
+        # If 'votes' is None and 'vote' is not 'VOTE_VALID', it's a single vote
+        inner_votes = {schemas.OptionIndex(1): vote.vote}
+
+    for inner_vote_index, inner_vote_value in inner_votes.items():
+        logger.info(
+            f"Processing vote for MP {mp_id} (in-term ID {vote.mp_term_id}) "
+            f"for voting option {inner_vote_index} "
+            f"in voting {voting.number} "
+            f"in sitting {sitting.number} in {term.number} term"
+        )
+        inner_vote_id = utils.get_vote_nk(
+            term=term,
+            sitting=sitting,
+            voting=voting,
+            voting_option_index=inner_vote_index,
+            mp_id=mp_id,
         )
 
-        if mp_id_query is None:
-            raise ValueError
+        voting_option_id = utils.get_voting_option_nk(
+            voting_option_index=inner_vote_index,
+            term=term,
+            sitting=sitting,
+            voting=voting,
+        )
 
-        mp_id = mp_id_query.mp_id
-
-        inner_votes = vote.votes
-        if inner_votes is None:
-            if vote.vote == "VOTE_VALID":
-                raise TypeError
-            inner_votes = {schemas.OptionIndex(1): vote.vote}
-
-        for inner_vote_index, inner_vote in inner_votes.items():
-            logger.info(
-                f"Processing vote {vote.mp_term_id} "
-                f"for voting option {inner_vote_index} "
-                f"in voting {voting.number} "
-                f"in sitting {sitting.number} in {term.number} term"
-            )
-            inner_vote_id = utils.get_vote_nk(
-                term=term,
-                sitting=sitting,
-                voting=voting,
-                voting_option_index=inner_vote_index,
-                mp_id=mp_id,
-            )
-
-            voting_option_id = utils.get_voting_option_nk(
-                voting_option_index=inner_vote_index,
-                term=term,
-                sitting=sitting,
-                voting=voting,
-            )
-
-            db_item = database.Votes(
-                id=inner_vote_id,
-                voting_option_id=voting_option_id,
-                mp_id=mp_id,
-                vote=inner_vote,
-                party=vote.party,
-            )
-            db.merge(db_item)
-            db.commit()
+        vote_data = {
+            "id": inner_vote_id,
+            "voting_option_id": voting_option_id,
+            "mp_id": mp_id,
+            "vote": inner_vote_value,
+            "party": vote.party,
+        }
+        processed_votes.append(vote_data)
+    return processed_votes
 
 
 def process_mp(
     mp: schemas.MpSchema,
-    term: schemas.TermSchema,
-) -> None:
+) -> Dict[str, Any]:  # Term is not needed here as mp_id is globally unique across terms based on schema
     logger.info(
-        f"Processing mp of in term id {mp.in_term_id} in {term.number} term"
+        f"Processing MP {mp.first_name} {mp.last_name} (in-term ID {mp.in_term_id})"
     )
     mp_id = utils.get_mp_nk(mp=mp)
-    with SessionMaker() as db:
-        db_item = database.MPs(
-            id=mp_id,
-            first_name=mp.first_name,
-            second_name=mp.second_name,
-            last_name=mp.last_name,
-            birth_date=mp.birth_date,
-            birth_place=mp.birth_place,
-        )
-        db.merge(db_item)
-        db.commit()
+    return {
+        "id": mp_id,
+        "first_name": mp.first_name,
+        "second_name": mp.second_name,
+        "last_name": mp.last_name,
+        "birth_date": mp.birth_date,
+        "birth_place": mp.birth_place,
+    }
 
 
 def process_mp_to_term_link(
     mp: schemas.MpSchema,
     term: schemas.TermSchema,
-) -> None:
+) -> Dict[str, Any]:
     logger.info(
-        f"Processing mp to term link of mp of in term id {mp.in_term_id} "
-        f"in {term.number} term"
+        f"Processing MP to term link for MP {mp.first_name} {mp.last_name} "
+        f"(in-term ID {mp.in_term_id}) in {term.number} term"
     )
     mp_to_term_link_id = utils.get_mp_to_term_link_nk(mp=mp, term=term)
     term_id = utils.get_term_nk(term)
     mp_id = utils.get_mp_nk(mp)
-    db_item = database.MpToTermLink(
-        id=mp_to_term_link_id,
-        mp_id=mp_id,
-        term_id=term_id,
-        in_term_id=mp.in_term_id,
-        education=mp.education,
-        profession=mp.profession,
-        voivodeship=mp.voivodeship,
-        district_name=mp.district_name,
-        inactivity_cause=mp.inactivity_cause,
-        inactivity_description=mp.inactivity_description,
-    )
-    with SessionMaker() as db:
-        db.merge(db_item)
-        db.commit()
+    return {
+        "id": mp_to_term_link_id,
+        "mp_id": mp_id,
+        "term_id": term_id,
+        "in_term_id": mp.in_term_id,
+        "education": mp.education,
+        "profession": mp.profession,
+        "voivodeship": mp.voivodeship,
+        "district_name": mp.district_name,
+        "inactivity_cause": mp.inactivity_cause,
+        "inactivity_description": mp.inactivity_description,
+    }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,84 @@
+import duckdb
+import pytest # For potential use of fixtures or markers later, good practice
+from sejm_scraper.database import create_tables_if_not_exists
+
+def test_create_tables_if_not_exists():
+    """
+    Tests the create_tables_if_not_exists function to ensure all tables
+    are created with the correct basic schema.
+    """
+    conn = None
+    try:
+        conn = duckdb.connect(':memory:')
+        create_tables_if_not_exists(conn)
+
+        # 1. Verify all expected tables are created
+        tables = conn.execute("SELECT table_name FROM duckdb_tables() WHERE schema_name='main' ORDER BY table_name;").fetchall()
+        table_names = [table[0] for table in tables]
+
+        expected_tables = sorted([
+            "Terms", "Sittings", "Votings", "VotingOptions", "MPs", "Votes", "MpToTermLink"
+        ])
+        assert table_names == expected_tables, f"Expected tables {expected_tables}, but got {table_names}"
+
+        # 2. Verify schema for 'Terms' table
+        terms_info = conn.execute("PRAGMA table_info('Terms')").fetchall()
+        # (cid, name, type, notnull, dflt_value, pk)
+        # For DuckDB: type can be e.g. 'INTEGER', 'VARCHAR', 'DATE', 'TIMESTAMP'
+        # notnull is 0 for False, 1 for True
+        # pk is 0 for False, 1 for True
+        
+        # Convert to a more comparable format: (name, type, notnull, pk)
+        # Note: dflt_value is often None, so we might skip it for simplicity unless specific defaults are set.
+        # For VARCHAR, DuckDB PRAGMA table_info might show 'VARCHAR' without size.
+        
+        # Helper to extract relevant parts for comparison
+        def extract_pragma_info(row):
+            return (row[1], row[2], row[3], row[5]) # name, type, notnull, pk
+
+        terms_schema = [extract_pragma_info(row) for row in terms_info]
+
+        assert ('id', 'VARCHAR', 0, 1) in terms_schema # id VARCHAR, notnull=0 (can be null if not PK, but it is PK), pk=1
+        assert ('number', 'INTEGER', 1, 0) in terms_schema # number INTEGER, notnull=1, pk=0
+        assert ('from_date', 'DATE', 1, 0) in terms_schema # from_date DATE, notnull=1, pk=0
+        assert ('to_date', 'DATE', 0, 0) in terms_schema # to_date DATE, notnull=0 (nullable), pk=0
+
+        # 3. Verify schema for 'Votes' table (as another example)
+        votes_info = conn.execute("PRAGMA table_info('Votes')").fetchall()
+        votes_schema = [extract_pragma_info(row) for row in votes_info]
+
+        assert ('id', 'VARCHAR', 0, 1) in votes_schema
+        assert ('voting_option_id', 'VARCHAR', 1, 0) in votes_schema # Foreign key, so NOT NULL
+        assert ('mp_id', 'VARCHAR', 1, 0) in votes_schema # Foreign key, so NOT NULL
+        assert ('vote', 'VARCHAR', 1, 0) in votes_schema
+        assert ('party', 'VARCHAR', 0, 0) in votes_schema # Nullable
+
+        # 4. Check Foreign Key constraints (example for Sittings referencing Terms)
+        # DuckDB's PRAGMA foreign_key_list(table_name) can be used.
+        # PRAGMA foreign_key_list('Sittings');
+        # Returns: id, seq, table, from, to, on_update, on_delete, match
+        
+        sittings_fk_info = conn.execute("PRAGMA foreign_key_list('Sittings');").fetchall()
+        # We expect one FK from Sittings.term_id to Terms.id
+        found_sittings_fk = False
+        for fk_row in sittings_fk_info:
+            if fk_row[2] == 'Terms' and fk_row[3] == 'term_id' and fk_row[4] == 'id':
+                found_sittings_fk = True
+                break
+        assert found_sittings_fk, "Foreign key from Sittings.term_id to Terms.id not found or misconfigured."
+
+        # Check a table with multiple FKs, e.g., Votes
+        votes_fk_info = conn.execute("PRAGMA foreign_key_list('Votes');").fetchall()
+        fk_targets_in_votes = {(fk[2], fk[3], fk[4]) for fk in votes_fk_info} # (referenced_table, from_col, to_col)
+        
+        assert ('VotingOptions', 'voting_option_id', 'id') in fk_targets_in_votes, \
+            "FK Votes.voting_option_id -> VotingOptions.id missing."
+        assert ('MPs', 'mp_id', 'id') in fk_targets_in_votes, \
+            "FK Votes.mp_id -> MPs.id missing."
+
+    finally:
+        if conn:
+            conn.close()
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,317 @@
+import duckdb
+import pytest # For potential use of fixtures or markers later
+from datetime import date, datetime
+
+from sejm_scraper import schemas, process, utils
+from sejm_scraper.database import create_tables_if_not_exists
+
+# --- Tests for Data Transformation ---
+
+def test_process_term():
+    sample_term_schema = schemas.TermSchema(num=10, current=True, from_date=date(2023, 1, 1), to_date=date(2023, 12, 31))
+    processed_data = process.process_term(sample_term_schema)
+    expected_id = utils.get_term_nk(sample_term_schema)
+    assert processed_data == {
+        "id": expected_id,
+        "number": 10,
+        "from_date": date(2023, 1, 1),
+        "to_date": date(2023, 12, 31)
+    }
+
+def test_process_mp():
+    sample_mp_schema = schemas.MpSchema(
+        id=123, # This ID from schema is not directly used for our primary key
+        first_name="Jan",
+        second_name="Maria",
+        last_name="Kowalski",
+        birth_date=date(1980, 5, 15),
+        birth_place="Warszawa",
+        district_num=20,
+        district_name="okręg warszawski",
+        voivodeship="Mazowieckie",
+        club="ABC",
+        num_of_votes=12345,
+        education="wyższe",
+        profession="prawnik",
+        email="jan.kowalski@sejm.pl",
+        active=True,
+        inactive_cause="",
+        waiver_desc="",
+        oath_date=date(2023,1,10),
+        in_term_id=99 # This is the mp_term_id or similar used in votes
+    )
+    processed_data = process.process_mp(sample_mp_schema)
+    expected_id = utils.get_mp_nk(sample_mp_schema) # Uses first_name, last_name, birth_date
+    assert processed_data == {
+        "id": expected_id,
+        "first_name": "Jan",
+        "second_name": "Maria",
+        "last_name": "Kowalski",
+        "birth_date": date(1980, 5, 15),
+        "birth_place": "Warszawa",
+    }
+
+def test_process_mp_to_term_link():
+    sample_term_schema = schemas.TermSchema(num=10, current=True, from_date=date(2023,1,1), to_date=date(2023,12,31))
+    sample_mp_schema = schemas.MpSchema(
+        id=123, first_name="Anna", second_name=None, last_name="Nowak",
+        birth_date=date(1975, 3, 3), birth_place="Kraków",
+        district_num=13, district_name="okręg krakowski", voivodeship="Małopolskie",
+        club="XYZ", num_of_votes=54321, education="średnie", profession="nauczyciel",
+        email="anna.nowak@sejm.pl", active=True, inactive_cause=None, waiver_desc=None,
+        oath_date=date(2023,1,11), in_term_id=101
+    )
+    processed_data = process.process_mp_to_term_link(sample_mp_schema, sample_term_schema)
+    expected_id = utils.get_mp_to_term_link_nk(mp=sample_mp_schema, term=sample_term_schema)
+    expected_term_id = utils.get_term_nk(sample_term_schema)
+    expected_mp_id = utils.get_mp_nk(sample_mp_schema)
+
+    assert processed_data == {
+        "id": expected_id,
+        "mp_id": expected_mp_id,
+        "term_id": expected_term_id,
+        "in_term_id": 101,
+        "education": "średnie",
+        "profession": "nauczyciel",
+        "voivodeship": "Małopolskie",
+        "district_name": "okręg krakowski",
+        "inactivity_cause": None,
+        "inactivity_description": None,
+    }
+
+def test_process_sitting():
+    sample_term_schema = schemas.TermSchema(num=9, current=True, from_date=date(2019,1,1), to_date=date(2023,12,31))
+    sample_sitting_schema = schemas.SittingSchema(
+        term=9, posiedzenie=5, nrPosiedzenia=5, title="Posiedzenie Sejmu",
+        dataOd=date(2023,2,10), dataDo=date(2023,2,12), number=5 # number is important
+    )
+    processed_data = process.process_sitting(sample_sitting_schema, sample_term_schema)
+    expected_term_id = utils.get_term_nk(sample_term_schema)
+    expected_sitting_id = utils.get_sitting_nk(sitting=sample_sitting_schema, term=sample_term_schema)
+
+    assert processed_data == {
+        "id": expected_sitting_id,
+        "term_id": expected_term_id,
+        "title": "Posiedzenie Sejmu",
+        "number": 5,
+    }
+
+    # Test skipping planned sittings (number=0)
+    planned_sitting_schema = schemas.SittingSchema(
+        term=9, posiedzenie=0, nrPosiedzenia=0, title="Planowane Posiedzenie",
+        dataOd=date(2023,3,1), dataDo=date(2023,3,1), number=0
+    )
+    assert process.process_sitting(planned_sitting_schema, sample_term_schema) is None
+
+def test_process_voting():
+    sample_term_schema = schemas.TermSchema(num=10, current=True, from_date=date(2023,1,1), to_date=date(2023,12,31))
+    sample_sitting_schema = schemas.SittingSchema(term=10, number=1, title="Sitting 1", dataOd=date(2023,2,1), dataDo=date(2023,2,1), posiedzenie=1, nrPosiedzenia=1)
+    sample_voting_schema = schemas.VotingSchema(
+        sitting=1, sitting_day=1, voting_number=3, date=datetime(2023,2,1,10,30,0),
+        title="Głosowanie nad ustawą X", description="Poprawka nr 5", topic="Ustawa o...",
+        voting_options=None # Will be handled separately if needed by process_voting_option
+    )
+    processed_data = process.process_voting(sample_voting_schema, sample_term_schema, sample_sitting_schema)
+    expected_voting_id = utils.get_voting_nk(voting=sample_voting_schema, term=sample_term_schema, sitting=sample_sitting_schema)
+    expected_sitting_id = utils.get_sitting_nk(sitting=sample_sitting_schema, term=sample_term_schema)
+
+    assert processed_data == {
+        "id": expected_voting_id,
+        "sitting_id": expected_sitting_id,
+        "sitting_day": 1,
+        "number": 3,
+        "date": datetime(2023,2,1,10,30,0),
+        "title": "Głosowanie nad ustawą X",
+        "description": "Poprawka nr 5",
+        "topic": "Ustawa o...",
+    }
+
+def test_process_voting_option():
+    sample_term_schema = schemas.TermSchema(num=10, current=True, from_date=date(2023,1,1), to_date=date(2023,12,31))
+    sample_sitting_schema = schemas.SittingSchema(term=10, number=1, title="Sitting 1", dataOd=date(2023,2,1), dataDo=date(2023,2,1), posiedzenie=1, nrPosiedzenia=1)
+    sample_voting_schema = schemas.VotingSchema(sitting=1, sitting_day=1, voting_number=3, date=datetime(2023,2,1,10,30,0), title="Głosowanie Y", voting_options=None)
+    sample_voting_option_schema = schemas.VotingOptionSchema(optionIndex=1, description="Za")
+
+    processed_data = process.process_voting_option(sample_voting_option_schema, sample_term_schema, sample_sitting_schema, sample_voting_schema)
+    expected_voting_id = utils.get_voting_nk(voting=sample_voting_schema, term=sample_term_schema, sitting=sample_sitting_schema)
+    expected_voting_option_id = utils.get_voting_option_nk(
+        voting_option_index=1, term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema
+    )
+    assert processed_data == {
+        "id": expected_voting_option_id,
+        "voting_id": expected_voting_id,
+        "index": 1,
+        "description": "Za",
+    }
+
+def test_process_vote():
+    sample_term_schema = schemas.TermSchema(num=10, current=True, from_date=date(2023,1,1), to_date=date(2023,12,31))
+    sample_sitting_schema = schemas.SittingSchema(term=10, number=1, title="Sitting 1", dataOd=date(2023,2,1), dataDo=date(2023,2,1), posiedzenie=1, nrPosiedzenia=1)
+    sample_voting_schema = schemas.VotingSchema(sitting=1, sitting_day=1, voting_number=3, date=datetime(2023,2,1,10,30,0), title="Głosowanie Z", voting_options=None)
+    
+    # Mock MP ID as it's passed directly
+    mock_mp_id = "mp_jan_kowalski_19800515"
+
+    # Case 1: vote.votes is None (single vote)
+    sample_mp_vote_schema_single = schemas.MpVoteSchema(
+        mp_term_id=99, # in_term_id
+        vote=schemas.VoteValue.VOTE_YES,
+        votes=None,
+        party="ABC"
+    )
+    processed_data_single = process.process_vote(
+        sample_term_schema, sample_sitting_schema, sample_voting_schema, sample_mp_vote_schema_single, mock_mp_id
+    )
+    expected_vote_id_single = utils.get_vote_nk(
+        term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema,
+        voting_option_index=schemas.OptionIndex(1), mp_id=mock_mp_id
+    )
+    expected_voting_option_id_single = utils.get_voting_option_nk(
+        voting_option_index=schemas.OptionIndex(1), term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema
+    )
+    assert len(processed_data_single) == 1
+    assert processed_data_single[0] == {
+        "id": expected_vote_id_single,
+        "voting_option_id": expected_voting_option_id_single,
+        "mp_id": mock_mp_id,
+        "vote": "VOTE_YES",
+        "party": "ABC",
+    }
+
+    # Case 2: vote.votes is populated (multiple options, e.g., personal votes)
+    sample_mp_vote_schema_multiple = schemas.MpVoteSchema(
+        mp_term_id=100,
+        vote=schemas.VoteValue.VOTE_VALID, # This is the overall status if votes dict is present
+        votes={
+            schemas.OptionIndex(1): schemas.VoteValue.VOTE_YES,
+            schemas.OptionIndex(2): schemas.VoteValue.VOTE_NO,
+        },
+        party="XYZ"
+    )
+    processed_data_multiple = process.process_vote(
+        sample_term_schema, sample_sitting_schema, sample_voting_schema, sample_mp_vote_schema_multiple, mock_mp_id
+    )
+    assert len(processed_data_multiple) == 2
+    
+    expected_vote_id_multi_1 = utils.get_vote_nk(
+        term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema,
+        voting_option_index=schemas.OptionIndex(1), mp_id=mock_mp_id
+    )
+    expected_voting_option_id_multi_1 = utils.get_voting_option_nk(
+        voting_option_index=schemas.OptionIndex(1), term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema
+    )
+    expected_vote_id_multi_2 = utils.get_vote_nk(
+        term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema,
+        voting_option_index=schemas.OptionIndex(2), mp_id=mock_mp_id
+    )
+    expected_voting_option_id_multi_2 = utils.get_voting_option_nk(
+        voting_option_index=schemas.OptionIndex(2), term=sample_term_schema, sitting=sample_sitting_schema, voting=sample_voting_schema
+    )
+
+    assert {
+        "id": expected_vote_id_multi_1,
+        "voting_option_id": expected_voting_option_id_multi_1,
+        "mp_id": mock_mp_id,
+        "vote": "VOTE_YES",
+        "party": "XYZ",
+    } in processed_data_multiple
+    assert {
+        "id": expected_vote_id_multi_2,
+        "voting_option_id": expected_voting_option_id_multi_2,
+        "mp_id": mock_mp_id,
+        "vote": "VOTE_NO",
+        "party": "XYZ",
+    } in processed_data_multiple
+
+    # Case 3: vote.votes is None and vote.vote is VOTE_VALID (should raise error, now returns empty list)
+    sample_mp_vote_schema_invalid = schemas.MpVoteSchema(
+        mp_term_id=101,
+        vote=schemas.VoteValue.VOTE_VALID,
+        votes=None,
+        party="QWE"
+    )
+    processed_data_invalid = process.process_vote(
+        sample_term_schema, sample_sitting_schema, sample_voting_schema, sample_mp_vote_schema_invalid, mock_mp_id
+    )
+    assert processed_data_invalid == []
+
+
+# --- Test for Bulk Insertion ---
+
+def test_bulk_insert_data():
+    conn = None
+    try:
+        conn = duckdb.connect(':memory:')
+        create_tables_if_not_exists(conn) # Setup schema
+
+        # Test with Terms table
+        sample_terms_data = [
+            {"id": "term_1", "number": 1, "from_date": date(2020, 1, 1), "to_date": date(2020, 12, 31)},
+            {"id": "term_2", "number": 2, "from_date": date(2021, 1, 1), "to_date": None},
+            {"id": "term_3", "number": 3, "from_date": date(2022, 1, 1), "to_date": date(2022, 6, 30)},
+        ]
+
+        # Test 1: Insert all data with chunk_size > len(data)
+        process.bulk_insert_data(conn, "Terms", sample_terms_data, process.TERMS_COLUMN_ORDER, chunk_size=10)
+        
+        count_result = conn.execute("SELECT COUNT(*) FROM Terms").fetchone()
+        assert count_result[0] == 3
+        
+        all_terms = conn.execute("SELECT id, number, from_date, to_date FROM Terms ORDER BY number").fetchall()
+        assert len(all_terms) == 3
+        assert all_terms[0] == ("term_1", 1, date(2020, 1, 1), date(2020, 12, 31))
+        assert all_terms[1] == ("term_2", 2, date(2021, 1, 1), None)
+        assert all_terms[2] == ("term_3", 3, date(2022, 1, 1), date(2022, 6, 30))
+
+        # Clear table for next test
+        conn.execute("DELETE FROM Terms")
+
+        # Test 2: Insert data with chunk_size < len(data) to test chunking
+        process.bulk_insert_data(conn, "Terms", sample_terms_data, process.TERMS_COLUMN_ORDER, chunk_size=2)
+        count_result_chunked = conn.execute("SELECT COUNT(*) FROM Terms").fetchone()
+        assert count_result_chunked[0] == 3
+        all_terms_chunked = conn.execute("SELECT id, number, from_date, to_date FROM Terms ORDER BY number").fetchall()
+        assert len(all_terms_chunked) == 3
+        assert all_terms_chunked[0] == ("term_1", 1, date(2020, 1, 1), date(2020, 12, 31))
+
+        # Test 3: Insert empty list
+        conn.execute("DELETE FROM Terms")
+        process.bulk_insert_data(conn, "Terms", [], process.TERMS_COLUMN_ORDER, chunk_size=10)
+        count_result_empty = conn.execute("SELECT COUNT(*) FROM Terms").fetchone()
+        assert count_result_empty[0] == 0
+
+        # Test 4: Data with missing key (should log error and skip the chunk)
+        conn.execute("DELETE FROM Terms")
+        sample_terms_bad_data = [
+            {"id": "term_4", "number": 4, "from_date": date(2023,1,1)}, # missing 'to_date'
+            {"id": "term_5", "number": 5, "from_date": date(2024,1,1), "to_date": date(2024,12,31)},
+        ]
+        # Assuming default behavior is to log and skip, not raise error and stop insertion of other chunks.
+        # The current implementation of bulk_insert_data logs an error and returns if a key is missing,
+        # effectively skipping the entire list of data if one item is bad.
+        process.bulk_insert_data(conn, "Terms", sample_terms_bad_data, process.TERMS_COLUMN_ORDER, chunk_size=1)
+        count_result_bad_data = conn.execute("SELECT COUNT(*) FROM Terms").fetchone()
+        # Given current logic, if one item is bad, the whole "data" list is skipped.
+        assert count_result_bad_data[0] == 0 
+
+        # Test with a valid item after a bad one to confirm previous behavior
+        conn.execute("DELETE FROM Terms")
+        sample_terms_mixed_data = [
+            {"id": "term_valid_1", "number": 6, "from_date": date(2025,1,1), "to_date": date(2025,12,31)},
+            # This bad data item will cause the whole list to be skipped by current bulk_insert_data logic
+            # {"id": "term_bad_key", "number": 7, "from_date_WRONG_KEY": date(2023,1,1)}, 
+            # {"id": "term_valid_2", "number": 8, "from_date": date(2026,1,1), "to_date": date(2026,12,31)},
+        ]
+        # Let's test only valid data again to ensure the table is usable.
+        valid_data_for_insert = [sample_terms_mixed_data[0]] # only the first valid item
+        process.bulk_insert_data(conn, "Terms", valid_data_for_insert, process.TERMS_COLUMN_ORDER, chunk_size=1)
+        count_result_valid_again = conn.execute("SELECT COUNT(*) FROM Terms").fetchone()
+        assert count_result_valid_again[0] == 1
+
+
+    finally:
+        if conn:
+            conn.close()
+
+if __name__ == "__main__":
+    pytest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,28 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/82/680b108da1870e48d98464ddcf03820f983421b5bbd8dd8beff98d583db7/duckdb-1.3.0.tar.gz", hash = "sha256:09aaa4b1dca24f4d1f231e7ae66b6413e317b7e04e2753541d42df6c8113fac7", size = 11617648, upload-time = "2025-05-21T16:06:49.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/b8/0931871f55a10aacd1af024c8d1e5de68337032379438aba05e26e9a1132/duckdb-1.3.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f24038fe9b83dcbaeafb1ed76ec3b3f38943c1c8d27ab464ad384db8a6658b61", size = 15516284, upload-time = "2025-05-21T16:05:51.596Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d5/a08f76900391ff248b18fc1d5742db4b7bcf910c4be00314ce7b3069223f/duckdb-1.3.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:956c85842841bef68f4a5388c6b225b933151a7c06d568390fc895fc44607913", size = 32490915, upload-time = "2025-05-21T16:05:54.731Z" },
+    { url = "https://files.pythonhosted.org/packages/05/f1/9dfa45484422bd6c598e76fb2d005de48373aea66b037471b4568c1e938a/duckdb-1.3.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:efe883d822ed56fcfbb6a7b397c13f6a0d2eaeb3bc4ef4510f84fadb3dfe416d", size = 17086690, upload-time = "2025-05-21T16:05:57.51Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4e/093944cbca2e4b3fe5da99c46df9f4ae293c6768f15f14a959aaa2064a50/duckdb-1.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3872a3a1b80ffba5264ea236a3754d0c41d3c7b01bdf8cdcb1c180fc1b8dc8e2", size = 19140518, upload-time = "2025-05-21T16:06:00.521Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/9e/b1a7c086db03f3cc85c513e70034bd515e68e25013875e5f0b40c4bf5d0a/duckdb-1.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:30bf45ad78a5a997f378863e036e917b481d18d685e5c977cd0a3faf2e31fbaf", size = 21103893, upload-time = "2025-05-21T16:06:03.643Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b4/5baef852efec9480dcfb44bed5adc56f6fcee09919037cf54fbbe87ac427/duckdb-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85cbd8e1d65df8a0780023baf5045d3033fabd154799bc9ea6d9ab5728f41eb3", size = 22753505, upload-time = "2025-05-21T16:06:06.773Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4f/f7ab120ecd827fdff59f14e1de9771335aa7656a29c3259fa7949de1f276/duckdb-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:8754c40dac0f26d9fb0363bbb5df02f7a61ce6a6728d5efc02c3bc925d7c89c3", size = 11424449, upload-time = "2025-05-21T16:06:09.43Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/d2666a682cda7152d0f391067e0307eec3e913b3462d2b5b944a3aab4d1d/duckdb-1.3.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:176b9818d940c52ac7f31c64a98cf172d7c19d2a006017c9c4e9c06c246e36bf", size = 15516004, upload-time = "2025-05-21T16:06:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/91/60/feb19a432c0b327b3d03171042acbafa688edb9a02f3034f7ae963d0f62d/duckdb-1.3.0-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:03981f7e8793f07a4a9a2ba387640e71d0a99ebcaf8693ab09f96d59e628b713", size = 32490147, upload-time = "2025-05-21T16:06:14.751Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/393beb10a24115347c8a4b75d59e6e1d49f7391722717a614bb71430673a/duckdb-1.3.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:a177d55a38a62fdf79b59a0eaa32531a1dbb443265f6d67f64992cc1e82b755c", size = 17086082, upload-time = "2025-05-21T16:06:17.511Z" },
+    { url = "https://files.pythonhosted.org/packages/71/45/da77973a7da7747385e16aa88c65a7b0e634585b5f7f92a6bb423838077c/duckdb-1.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1c30e3749823147d5578bc3f01f35d1a0433a1c768908d946056ec8d6e1757e", size = 19141643, upload-time = "2025-05-21T16:06:20.862Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/adc86c800e7ecfe828e94cccc28ac727b54a886124da08e3808cf77bf1b9/duckdb-1.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5855f3a564baf22eeeab70c120b51f5a11914f1f1634f03382daeb6b1dea4c62", size = 21102444, upload-time = "2025-05-21T16:06:23.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9d/ac3a6ddcaaf9bbd5584bb471794f017498326d11f754ee28b3c0a5c7aee8/duckdb-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1fac15a48056f7c2739cf8800873063ba2f691e91a9b2fc167658a401ca76a", size = 22752802, upload-time = "2025-05-21T16:06:26.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e9/f83285b0cb3729f24321a038f272490dfb76ca531b7cef832037b7bd077c/duckdb-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:fbdfc1c0b83b90f780ae74038187ee696bb56ab727a289752372d7ec42dda65b", size = 11424430, upload-time = "2025-05-21T16:06:28.878Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -170,37 +192,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/bdc8274dc0585090b4e3432267d7be4dfbfd8971c0fa59167c711105a6bf/psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2", size = 385764, upload-time = "2024-10-16T11:24:58.126Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/7d/465cc9795cf76f6d329efdafca74693714556ea3891813701ac1fee87545/psycopg2_binary-2.9.10-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:880845dfe1f85d9d5f7c412efea7a08946a46894537e4e5d091732eb1d34d9a0", size = 3044771, upload-time = "2024-10-16T11:20:35.234Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/31/6d225b7b641a1a2148e3ed65e1aa74fc86ba3fee850545e27be9e1de893d/psycopg2_binary-2.9.10-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9440fa522a79356aaa482aa4ba500b65f28e5d0e63b801abf6aa152a29bd842a", size = 3275336, upload-time = "2024-10-16T11:20:38.742Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b7/a68c2b4bff1cbb1728e3ec864b2d92327c77ad52edcd27922535a8366f68/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3923c1d9870c49a2d44f795df0c889a22380d36ef92440ff618ec315757e539", size = 2851637, upload-time = "2024-10-16T11:20:42.145Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b1/cfedc0e0e6f9ad61f8657fd173b2f831ce261c02a08c0b09c652b127d813/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b2c956c028ea5de47ff3a8d6b3cc3330ab45cf0b7c3da35a2d6ff8420896526", size = 3082097, upload-time = "2024-10-16T11:20:46.185Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ed/0a8e4153c9b769f59c02fb5e7914f20f0b2483a19dae7bf2db54b743d0d0/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f758ed67cab30b9a8d2833609513ce4d3bd027641673d4ebc9c067e4d208eec1", size = 3264776, upload-time = "2024-10-16T11:20:50.879Z" },
-    { url = "https://files.pythonhosted.org/packages/10/db/d09da68c6a0cdab41566b74e0a6068a425f077169bed0946559b7348ebe9/psycopg2_binary-2.9.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cd9b4f2cfab88ed4a9106192de509464b75a906462fb846b936eabe45c2063e", size = 3020968, upload-time = "2024-10-16T11:20:56.819Z" },
-    { url = "https://files.pythonhosted.org/packages/94/28/4d6f8c255f0dfffb410db2b3f9ac5218d959a66c715c34cac31081e19b95/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dc08420625b5a20b53551c50deae6e231e6371194fa0651dbe0fb206452ae1f", size = 2872334, upload-time = "2024-10-16T11:21:02.411Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f7/20d7bf796593c4fea95e12119d6cc384ff1f6141a24fbb7df5a668d29d29/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d7cd730dfa7c36dbe8724426bf5612798734bff2d3c3857f36f2733f5bfc7c00", size = 2822722, upload-time = "2024-10-16T11:21:09.01Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/e4/0c407ae919ef626dbdb32835a03b6737013c3cc7240169843965cada2bdf/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:155e69561d54d02b3c3209545fb08938e27889ff5a10c19de8d23eb5a41be8a5", size = 2920132, upload-time = "2024-10-16T11:21:16.339Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/70/aa69c9f69cf09a01da224909ff6ce8b68faeef476f00f7ec377e8f03be70/psycopg2_binary-2.9.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3cc28a6fd5a4a26224007712e79b81dbaee2ffb90ff406256158ec4d7b52b47", size = 2959312, upload-time = "2024-10-16T11:21:25.584Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bd/213e59854fafe87ba47814bf413ace0dcee33a89c8c8c814faca6bc7cf3c/psycopg2_binary-2.9.10-cp312-cp312-win32.whl", hash = "sha256:ec8a77f521a17506a24a5f626cb2aee7850f9b69a0afe704586f63a464f3cd64", size = 1025191, upload-time = "2024-10-16T11:21:29.912Z" },
-    { url = "https://files.pythonhosted.org/packages/92/29/06261ea000e2dc1e22907dbbc483a1093665509ea586b29b8986a0e56733/psycopg2_binary-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:18c5ee682b9c6dd3696dad6e54cc7ff3a1a9020df6a5c0f861ef8bfd338c3ca0", size = 1164031, upload-time = "2024-10-16T11:21:34.211Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/30/d41d3ba765609c0763505d565c4d12d8f3c79793f0d0f044ff5a28bf395b/psycopg2_binary-2.9.10-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:26540d4a9a4e2b096f1ff9cce51253d0504dca5a85872c7f7be23be5a53eb18d", size = 3044699, upload-time = "2024-10-16T11:21:42.841Z" },
-    { url = "https://files.pythonhosted.org/packages/35/44/257ddadec7ef04536ba71af6bc6a75ec05c5343004a7ec93006bee66c0bc/psycopg2_binary-2.9.10-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e217ce4d37667df0bc1c397fdcd8de5e81018ef305aed9415c3b093faaeb10fb", size = 3275245, upload-time = "2024-10-16T11:21:51.989Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/11/48ea1cd11de67f9efd7262085588790a95d9dfcd9b8a687d46caf7305c1a/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:245159e7ab20a71d989da00f280ca57da7641fa2cdcf71749c193cea540a74f7", size = 2851631, upload-time = "2024-10-16T11:21:57.584Z" },
-    { url = "https://files.pythonhosted.org/packages/62/e0/62ce5ee650e6c86719d621a761fe4bc846ab9eff8c1f12b1ed5741bf1c9b/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c4ded1a24b20021ebe677b7b08ad10bf09aac197d6943bfe6fec70ac4e4690d", size = 3082140, upload-time = "2024-10-16T11:22:02.005Z" },
-    { url = "https://files.pythonhosted.org/packages/27/ce/63f946c098611f7be234c0dd7cb1ad68b0b5744d34f68062bb3c5aa510c8/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3abb691ff9e57d4a93355f60d4f4c1dd2d68326c968e7db17ea96df3c023ef73", size = 3264762, upload-time = "2024-10-16T11:22:06.412Z" },
-    { url = "https://files.pythonhosted.org/packages/43/25/c603cd81402e69edf7daa59b1602bd41eb9859e2824b8c0855d748366ac9/psycopg2_binary-2.9.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8608c078134f0b3cbd9f89b34bd60a943b23fd33cc5f065e8d5f840061bd0673", size = 3020967, upload-time = "2024-10-16T11:22:11.583Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/d6/8708d8c6fca531057fa170cdde8df870e8b6a9b136e82b361c65e42b841e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:230eeae2d71594103cd5b93fd29d1ace6420d0b86f4778739cb1a5a32f607d1f", size = 2872326, upload-time = "2024-10-16T11:22:16.406Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ac/5b1ea50fc08a9df82de7e1771537557f07c2632231bbab652c7e22597908/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909", size = 2822712, upload-time = "2024-10-16T11:22:21.366Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/fc/504d4503b2abc4570fac3ca56eb8fed5e437bf9c9ef13f36b6621db8ef00/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1", size = 2920155, upload-time = "2024-10-16T11:22:25.684Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d1/323581e9273ad2c0dbd1902f3fb50c441da86e894b6e25a73c3fda32c57e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567", size = 2959356, upload-time = "2024-10-16T11:22:30.562Z" },
-    { url = "https://files.pythonhosted.org/packages/08/50/d13ea0a054189ae1bc21af1d85b6f8bb9bbc5572991055d70ad9006fe2d6/psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142", size = 2569224, upload-time = "2025-01-04T20:09:19.234Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.11.4"
 source = { registry = "https://pypi.org/simple" }
@@ -284,9 +275,9 @@ name = "sejm-scraper"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "duckdb" },
     { name = "httpx" },
     { name = "loguru" },
-    { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "sqlalchemy" },
     { name = "tenacity" },
@@ -295,9 +286,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "duckdb", specifier = ">=1.3.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.4" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "tenacity", specifier = ">=9.1.2" },


### PR DESCRIPTION
…implement bulk inserts.

This commit addresses the issue of migrating the Sejm scraper from PostgreSQL to DuckDB, improving performance and simplifying deployment.

Key changes include:

- Replaced `psycopg2-binary` with `duckdb` dependency.
- Updated database interaction logic in `database.py` to use DuckDB, including dynamic table creation based on the existing schema definitions.
- Modified `process.py` to decouple data transformation from database I/O. Processing functions now return data structures, and a new `bulk_insert_data` function handles chunked inserts into DuckDB.
- Refactored `api_client.py` to use `httpx.AsyncClient` for asynchronous API calls.
- Significantly updated `main.py`:
    - API calls are now made concurrently using `asyncio.gather` and a configurable parallelism limit.
    - Data is collected from API responses, processed, and then bulk-inserted into DuckDB in configurable chunks.
    - The `mp_id` required for vote processing is now resolved via a lookup after relevant MP data for a term is inserted.
    - `prepare_database` and `resume` commands are updated for DuckDB.
- Configuration:
    - DuckDB database file path is configurable via the `SEJM_SCRAPER_DUCKDB_FILE` environment variable and a `--db-path` CLI option.
    - API call parallelism (`--parallelism-limit`) and bulk insert chunk size (`--chunk-size`) are configurable via CLI options.
- Added comprehensive unit tests for:
    - DuckDB table creation logic.
    - Data transformation functions in `process.py`.
    - Bulk data insertion into DuckDB.

These changes aim to make the scraper more efficient and easier to manage by leveraging DuckDB's in-process analytics capabilities and simplifying the data pipeline.