### PR TITLE
feat(cli): option docs and; rename DEBUG

### DIFF
--- a/src/sejm_scraper/__init__.py
+++ b/src/sejm_scraper/__init__.py
@@ -3,13 +3,13 @@ import sys
 
 from loguru import logger
 
-DEBUG = os.getenv("SEJM_SCRAPER_DEBUG", None) == "true"
+IS_DEBUG = os.getenv("SEJM_SCRAPER_DEBUG", None) == "true"
 
 logger.configure(
     handlers=[
         {
             "sink": sys.stdout,
-            "level": "DEBUG" if DEBUG else "INFO",
+            "level": "DEBUG" if IS_DEBUG else "INFO",
         }
     ]
 )

--- a/src/sejm_scraper/__main__.py
+++ b/src/sejm_scraper/__main__.py
@@ -8,17 +8,27 @@ app = typer.Typer()
 @app.command()
 def start_pipeline(
     from_term: int = typer.Option(
-        None, help="Start from a specific term number"
+        None,
+        help="Start from a specific term number.",
     ),
     from_sitting: int = typer.Option(
-        None, help="Start from a specific sitting number"
+        None,
+        help="Start from a specific sitting number, requires from_term.",
     ),
     from_voting: int = typer.Option(
-        None, help="Start from a specific voting number"
+        None,
+        help=(
+            "Start from a specific voting number,"
+            " requires from_sitting and from_term."
+        ),
     ),
 ) -> None:
     """Start the scraping pipeline to collect data from the Sejm API."""
-    pipeline.start_pipeline(from_term, from_sitting, from_voting)
+    pipeline.start_pipeline(
+        from_term,
+        from_sitting,
+        from_voting,
+    )
 
 
 @app.command()

--- a/src/sejm_scraper/api_client.py
+++ b/src/sejm_scraper/api_client.py
@@ -1,5 +1,3 @@
-from typing import TypeVar
-
 import httpx
 from loguru import logger
 from pydantic import BaseModel
@@ -14,8 +12,6 @@ RETRY_SETTINGS = {
 }
 BASE_URL = "https://api.sejm.gov.pl/sejm"
 TIMEOUT = 30
-
-T = TypeVar("T", bound=BaseModel)
 
 
 @retry(**RETRY_SETTINGS)


### PR DESCRIPTION
- Clarify CLI option help texts for start_pipeline:
  - Add periods and explicit dependency notes:
    - from_term: "Start from a specific term number."
    - from_sitting: "Start from a specific sitting number, requires from_term."
    - from_voting: "Start from a specific voting number, requires from_sitting and from_term."
  - Reformat long help string for from_voting to a combined literal for readability.
  - Reformat pipeline.start_pipeline call to use one argument per line for clearer diffs.

- Rename DEBUG constant to IS_DEBUG in package init to avoid a
  potentially ambiguous global name and improve readability.

- Update logger configuration to reference IS_DEBUG.

- Remove unused imports and unused TypeVar in api_client:
  - Drop unused typing.TypeVar and the unused T bound to BaseModel.

Rationale:
- Improve CLI UX by making help texts clearer about parameter
  dependencies.
- Improve code clarity and maintainability by renaming globals,
  removing unused symbols, and formatting calls for easier review.