### PR TITLE
Refactor pipeline to commit atomically per sitting and limit concurrent requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: "Test"
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Full project documentation is available at [DeepWiki](https://deepwiki.com/LuxF3
 ## Features
 
 - Normalized data model with primary keys, foreign keys, and not-null constraints.
-- Async HTTP with unlimited concurrent vote scraping per sitting.
-- Retry logic for flaky API responses.
+- Async HTTP with bounded concurrent vote scraping (10 requests at a time).
+- Retry logic for transient API failures (timeouts, connection errors, 429/5xx).
 - Embedded DuckDB — no database server needed.
 - Resume from any term, sitting, or voting.
 
@@ -122,6 +122,7 @@ erDiagram
     VoteRecord {
         str id PK
         str voting_option_id FK
+        str mp_to_term_link_id FK
         int mp_term_id
         str vote
         str party
@@ -173,6 +174,7 @@ erDiagram
     Voting ||--o{ VotingOption : "has"
     VotingOption ||--o{ VoteRecord : "has"
     Mp ||--o{ MpToTermLink : "has"
+    MpToTermLink ||--o{ VoteRecord : "casts"
 ```
 
 ## Getting started
@@ -211,6 +213,12 @@ Or start from a specific point:
 uv run sejm-scraper scrape --from-term 10
 uv run sejm-scraper scrape --from-term 10 --from-sitting 5
 uv run sejm-scraper scrape --from-term 10 --from-sitting 5 --from-voting 3
+```
+
+All commands accept `--db-path` to use a database file other than the default `sejm_scraper.duckdb`:
+
+```console
+uv run sejm-scraper scrape --db-path my_data.duckdb
 ```
 
 ### Resume

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,6 @@ lint.ignore = [
     "PLR0912",
     "PLR0913",
     "PLR0915",
-    "D211",    # no-blank-line-before-class
-    "D213",    # multi-line-summary-second-line
     "ISC001",  # single-line-implicit-string-concatenation
     "UP007",   # keep Union syntax for pydantic
 ]

--- a/src/sejm_scraper/api_client.py
+++ b/src/sejm_scraper/api_client.py
@@ -1,12 +1,39 @@
 import httpx
 from pydantic import BaseModel
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from sejm_scraper import api_schemas
+
+_HTTP_TOO_MANY_REQUESTS = 429
+_HTTP_INTERNAL_SERVER_ERROR = 500
+
+
+def _is_retryable_error(exception: BaseException) -> bool:
+    """Return True for transient failures that are worth retrying.
+
+    Retries transport-level errors (timeouts, connection failures) and
+    HTTP 429/5xx responses. Other client errors (4xx) and response
+    validation errors are not retried, as repeating the request cannot
+    fix them.
+    """
+    if isinstance(exception, httpx.HTTPStatusError):
+        status_code = exception.response.status_code
+        return (
+            status_code == _HTTP_TOO_MANY_REQUESTS
+            or status_code >= _HTTP_INTERNAL_SERVER_ERROR
+        )
+    return isinstance(exception, httpx.TransportError)
+
 
 RETRY_SETTINGS = {
     "stop": stop_after_attempt(3),
     "wait": wait_exponential(multiplier=1, min=4, max=30),
+    "retry": retry_if_exception(_is_retryable_error),
     "reraise": True,
 }
 BASE_URL = "https://api.sejm.gov.pl/sejm"

--- a/src/sejm_scraper/cli.py
+++ b/src/sejm_scraper/cli.py
@@ -2,16 +2,28 @@
 
 import anyio
 import typer
+from sqlalchemy import Engine
 
 from sejm_scraper import database, pipeline
 
 app = typer.Typer(help="Scrape Polish Sejm parliamentary data.")
 
+DEFAULT_DB_PATH = "sejm_scraper.duckdb"
+
+_DB_PATH_HELP = "Path to the DuckDB database file."
+
+
+def _engine_from_path(db_path: str) -> Engine:
+    return database.get_engine(url=f"duckdb:///{db_path}")
+
 
 @app.command()
-def prepare_database() -> None:
+def prepare_database(
+    *,
+    db_path: str = typer.Option(DEFAULT_DB_PATH, help=_DB_PATH_HELP),
+) -> None:
     """Create all database tables."""
-    database.create_db_and_tables()
+    database.create_db_and_tables(engine=_engine_from_path(db_path))
 
 
 @app.command()
@@ -30,11 +42,13 @@ def scrape(
             "(requires --from-term and --from-sitting)."
         ),
     ),
+    db_path: str = typer.Option(DEFAULT_DB_PATH, help=_DB_PATH_HELP),
 ) -> None:
     """Run the full scraping pipeline."""
 
     async def _run() -> None:
         await pipeline.pipeline(
+            engine=_engine_from_path(db_path),
             from_term=from_term,
             from_sitting=from_sitting,
             from_voting=from_voting,
@@ -44,10 +58,13 @@ def scrape(
 
 
 @app.command()
-def resume() -> None:
+def resume(
+    *,
+    db_path: str = typer.Option(DEFAULT_DB_PATH, help=_DB_PATH_HELP),
+) -> None:
     """Resume scraping from the last completed point in the database."""
 
     async def _run() -> None:
-        await pipeline.resume_pipeline()
+        await pipeline.resume_pipeline(engine=_engine_from_path(db_path))
 
     anyio.run(_run)

--- a/src/sejm_scraper/database.py
+++ b/src/sejm_scraper/database.py
@@ -1,9 +1,12 @@
+import json
+import os
+import tempfile
 from collections.abc import Sequence
 from datetime import date
-from typing import Union
+from typing import Any, Union
 
 import sqlmodel
-from sqlalchemy import Engine
+from sqlalchemy import Boolean, Column, Date, Engine, Integer
 from sqlmodel import Field, SQLModel, create_engine
 
 from sejm_scraper.api_schemas import Vote
@@ -131,15 +134,17 @@ def bulk_upsert(
     model: type[SQLModel],
     records: Sequence[SQLModel],
 ) -> None:
-    """Bulk upsert records using DuckDB's INSERT OR REPLACE.
+    """Bulk upsert records using DuckDB's vectorized INSERT OR REPLACE.
 
     SQLAlchemy's ORM `session.merge()` / `session.add()` issues one
-    INSERT per row through the full ORM machinery, which is extremely
-    slow for the thousands of vote records per sitting. This function
-    bypasses that path by executing a single prepared
-    `INSERT OR REPLACE` statement over all rows with `executemany` on
-    the native DuckDB connection. Parameter binding also avoids the
-    type-inference pitfalls of file-based loading (`read_json_auto`).
+    INSERT per row, and DuckDB's `executemany` likewise executes the
+    prepared statement row by row — both are extremely slow for the
+    thousands of vote records per sitting. This function bypasses those
+    paths by serialising records to a JSON temp file and loading them
+    in a single `INSERT OR REPLACE ... SELECT FROM read_json(...)`
+    statement, letting DuckDB handle the bulk load with its vectorized
+    execution engine. Column types are passed to `read_json` explicitly
+    (derived from the table schema), so no type inference is involved.
 
     Args:
         session: Active SQLModel session.
@@ -149,21 +154,59 @@ def bulk_upsert(
     if not records:
         return
     table = model.__table__  # type: ignore[attr-defined]  # SQLModel tables have __table__ at runtime
-    columns = [col.name for col in table.columns]
-    col_names = ", ".join(columns)
-    placeholders = ", ".join(["?"] * len(columns))
+    columns = list(table.columns)
+    col_names = ", ".join(col.name for col in columns)
+    col_types = ", ".join(
+        f"'{col.name}': '{_duckdb_column_type(col)}'" for col in columns
+    )
 
-    rows = [[getattr(r, col) for col in columns] for r in records]
+    rows = [
+        {col.name: _json_safe(getattr(r, col.name)) for col in columns}
+        for r in records
+    ]
 
     # duckdb-engine's ConnectionWrapper proxies attribute access to
-    # the raw DuckDBPyConnection via __getattr__, so .executemany()
+    # the raw DuckDBPyConnection via __getattr__, so .execute()
     # works directly against the native DuckDB connection.
     dbapi_conn = session.connection().connection.dbapi_connection
-    dbapi_conn.executemany(  # type: ignore[union-attr]  # guaranteed non-None inside active session
-        f"INSERT OR REPLACE INTO {table.name} ({col_names}) "  # noqa: S608
-        f"VALUES ({placeholders})",
-        rows,
-    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        delete=False,
+        encoding="utf-8",
+    ) as f:
+        json.dump(rows, f)
+        tmp_path = f.name
+
+    try:
+        path = tmp_path.replace("\\", "/")
+        dbapi_conn.execute(  # type: ignore[union-attr]  # guaranteed non-None inside active session
+            f"INSERT OR REPLACE INTO {table.name} ({col_names}) "  # noqa: S608
+            f"SELECT {col_names} FROM read_json('{path}', "
+            f"format='array', columns={{{col_types}}})"
+        )
+    finally:
+        os.unlink(tmp_path)
+
+
+def _duckdb_column_type(column: "Column[Any]") -> str:
+    """Map a SQLAlchemy column type to an explicit DuckDB type."""
+    if isinstance(column.type, Boolean):
+        return "BOOLEAN"
+    if isinstance(column.type, Integer):
+        return "BIGINT"
+    if isinstance(column.type, Date):
+        return "DATE"
+    # Strings and string-backed enums
+    return "VARCHAR"
+
+
+def _json_safe(value: object) -> object:
+    """Convert values that `json.dump` cannot serialise natively."""
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
 
 
 def create_db_and_tables(*, engine: Engine | None = None) -> None:

--- a/src/sejm_scraper/database.py
+++ b/src/sejm_scraper/database.py
@@ -1,6 +1,3 @@
-import json
-import os
-import tempfile
 from collections.abc import Sequence
 from datetime import date
 from typing import Union
@@ -100,6 +97,11 @@ class Mp(SQLModel, table=True):
 class VoteRecord(SQLModel, table=True):
     id: str = Field(primary_key=True)
     voting_option_id: str = Field(foreign_key="votingoption.id")
+    # Nullable because a vote may reference an MP missing from the
+    # term's MP list (the API is not consistent about this).
+    mp_to_term_link_id: Union[str, None] = Field(
+        default=None, foreign_key="mptotermlink.id"
+    )
     mp_term_id: int
     vote: Vote
     party: Union[str, None]
@@ -129,15 +131,15 @@ def bulk_upsert(
     model: type[SQLModel],
     records: Sequence[SQLModel],
 ) -> None:
-    """Bulk upsert records using DuckDB's vectorized INSERT OR REPLACE.
+    """Bulk upsert records using DuckDB's INSERT OR REPLACE.
 
     SQLAlchemy's ORM `session.merge()` / `session.add()` issues one
-    INSERT per row, which is extremely slow for the thousands of vote
-    records per sitting. This function bypasses that path entirely by
-    serialising records to a JSON temp file and loading them in a single
-    `INSERT OR REPLACE ... SELECT FROM read_json_auto(...)` statement,
-    letting DuckDB handle the bulk load with its vectorized execution
-    engine.
+    INSERT per row through the full ORM machinery, which is extremely
+    slow for the thousands of vote records per sitting. This function
+    bypasses that path by executing a single prepared
+    `INSERT OR REPLACE` statement over all rows with `executemany` on
+    the native DuckDB connection. Parameter binding also avoids the
+    type-inference pitfalls of file-based loading (`read_json_auto`).
 
     Args:
         session: Active SQLModel session.
@@ -149,40 +151,19 @@ def bulk_upsert(
     table = model.__table__  # type: ignore[attr-defined]  # SQLModel tables have __table__ at runtime
     columns = [col.name for col in table.columns]
     col_names = ", ".join(columns)
+    placeholders = ", ".join(["?"] * len(columns))
 
-    rows = [
-        {col: _json_safe(getattr(r, col)) for col in columns} for r in records
-    ]
+    rows = [[getattr(r, col) for col in columns] for r in records]
 
     # duckdb-engine's ConnectionWrapper proxies attribute access to
-    # the raw DuckDBPyConnection via __getattr__, so .execute()
+    # the raw DuckDBPyConnection via __getattr__, so .executemany()
     # works directly against the native DuckDB connection.
     dbapi_conn = session.connection().connection.dbapi_connection
-
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".json",
-        delete=False,
-        encoding="utf-8",
-    ) as f:
-        json.dump(rows, f)
-        tmp_path = f.name
-
-    try:
-        path = tmp_path.replace("\\", "/")
-        dbapi_conn.execute(  # type: ignore[union-attr]  # guaranteed non-None inside active session
-            f"INSERT OR REPLACE INTO {table.name} ({col_names}) "  # noqa: S608
-            f"SELECT {col_names} FROM read_json_auto('{path}')"
-        )
-    finally:
-        os.unlink(tmp_path)
-
-
-def _json_safe(value: object) -> object:
-    """Convert values that `json.dump` cannot serialise natively."""
-    if isinstance(value, date):
-        return value.isoformat()
-    return value
+    dbapi_conn.executemany(  # type: ignore[union-attr]  # guaranteed non-None inside active session
+        f"INSERT OR REPLACE INTO {table.name} ({col_names}) "  # noqa: S608
+        f"VALUES ({placeholders})",
+        rows,
+    )
 
 
 def create_db_and_tables(*, engine: Engine | None = None) -> None:

--- a/src/sejm_scraper/pipeline.py
+++ b/src/sejm_scraper/pipeline.py
@@ -6,6 +6,126 @@ from sqlalchemy import Engine
 
 from sejm_scraper import database, scrape
 
+# Cap on simultaneous requests to the Sejm API when scraping votes.
+# The API is a public government service; hammering it with hundreds
+# of concurrent requests risks throttling or bans.
+MAX_CONCURRENT_VOTE_REQUESTS = 10
+
+
+async def _scrape_voting_votes(
+    client: httpx.AsyncClient,
+    limiter: anyio.CapacityLimiter,
+    term: database.Term,
+    sitting: database.Sitting,
+    voting: database.Voting,
+    mp_link_ids: dict[int, str],
+    all_votes: list[database.VoteRecord],
+    all_detail_options: list[database.VotingOption],
+) -> None:
+    async with limiter:
+        result = await scrape.scrape_votes(
+            client=client,
+            term=term,
+            sitting=sitting,
+            voting=voting,
+            mp_link_ids=mp_link_ids,
+        )
+    all_votes.extend(result.votes)
+    all_detail_options.extend(result.voting_options)
+    logger.info(
+        "term {term}, sitting {sitting}, "
+        "voting {voting}: scraped {count} votes",
+        term=term.number,
+        sitting=sitting.number,
+        voting=voting.number,
+        count=len(result.votes),
+    )
+
+
+async def _process_sitting(
+    *,
+    http_client: httpx.AsyncClient,
+    database_client: sqlmodel.Session,
+    limiter: anyio.CapacityLimiter,
+    term: database.Term,
+    sitting: database.Sitting,
+    sitting_days: list[database.SittingDay],
+    mp_link_ids: dict[int, str],
+    from_voting: int | None,
+) -> None:
+    """Scrape and persist all votings and votes for a single sitting.
+
+    The sitting row is committed before any votings are scraped, and
+    votings are committed together with their votes only after all
+    network I/O for the sitting has finished. This keeps the database
+    consistent with the resume logic: a crash mid-sitting leaves the
+    sitting without votings, so `resume_pipeline` restarts from this
+    sitting instead of skipping the unfinished work.
+    """
+    database.bulk_upsert(
+        session=database_client,
+        model=database.Sitting,
+        records=[sitting],
+    )
+    database.bulk_upsert(
+        session=database_client,
+        model=database.SittingDay,
+        records=sitting_days,
+    )
+    database_client.commit()
+
+    scraped_votings = await scrape.scrape_votings(
+        client=http_client,
+        term=term,
+        sitting=sitting,
+        from_voting=from_voting,
+    )
+
+    all_votes: list[database.VoteRecord] = []
+    all_detail_options: list[database.VotingOption] = []
+
+    async with anyio.create_task_group() as tg:
+        for voting in scraped_votings.votings:
+            tg.start_soon(
+                _scrape_voting_votes,
+                http_client,
+                limiter,
+                term,
+                sitting,
+                voting,
+                mp_link_ids,
+                all_votes,
+                all_detail_options,
+            )
+
+    database.bulk_upsert(
+        session=database_client,
+        model=database.Voting,
+        records=scraped_votings.votings,
+    )
+    database.bulk_upsert(
+        session=database_client,
+        model=database.VotingOption,
+        records=scraped_votings.voting_options,
+    )
+    database.bulk_upsert(
+        session=database_client,
+        model=database.VotingOption,
+        records=all_detail_options,
+    )
+    database.bulk_upsert(
+        session=database_client,
+        model=database.VoteRecord,
+        records=all_votes,
+    )
+    database_client.commit()
+    logger.info(
+        "term {term}, sitting {sitting}: scraped {count} votings",
+        term=term.number,
+        sitting=sitting.number,
+        count=len(scraped_votings.votings),
+    )
+
 
 async def pipeline(
     *,
@@ -15,6 +135,11 @@ async def pipeline(
     from_voting: int | None = None,
 ) -> None:
     """Run the full scraping pipeline.
+
+    Records are committed in the same order and granularity that
+    `resume_pipeline` uses to infer the resume point: each term and
+    sitting is committed when processing of it starts, and a sitting's
+    votings are committed atomically with their votes once complete.
 
     Args:
         engine: SQLAlchemy engine to use. Defaults to a new engine
@@ -45,22 +170,28 @@ async def pipeline(
 
     database.create_db_and_tables(engine=engine)
 
+    limiter = anyio.CapacityLimiter(MAX_CONCURRENT_VOTE_REQUESTS)
+
     async with httpx.AsyncClient() as http_client:
         with sqlmodel.Session(engine) as database_client:
             # Terms
             terms = await scrape.scrape_terms(
                 client=http_client, from_term=from_term
             )
-            database.bulk_upsert(
-                session=database_client,
-                model=database.Term,
-                records=terms,
-            )
-            database_client.commit()
+            # Process in ascending order so the highest committed
+            # term number is always the last one started.
+            terms.sort(key=lambda t: t.number)
             logger.info("scraped {count} terms", count=len(terms))
 
-            # Mps, Clubs & Sittings
             for term in terms:
+                database.bulk_upsert(
+                    session=database_client,
+                    model=database.Term,
+                    records=[term],
+                )
+                database_client.commit()
+
+                # Mps & Clubs
                 scraped_mps = await scrape.scrape_mps(
                     client=http_client, term=term
                 )
@@ -80,6 +211,10 @@ async def pipeline(
                     term=term.number,
                     mp_count=len(scraped_mps.mps),
                 )
+                mp_link_ids = {
+                    link.in_term_id: link.id
+                    for link in scraped_mps.mp_to_term_links
+                }
 
                 scraped_clubs = await scrape.scrape_clubs(
                     client=http_client, term=term
@@ -96,6 +231,7 @@ async def pipeline(
                     club_count=len(scraped_clubs),
                 )
 
+                # Sittings
                 effective_from_sitting = (
                     from_sitting if term.number == from_term else None
                 )
@@ -119,110 +255,43 @@ async def pipeline(
                             term=term.number,
                             count=len(scraped_sittings.sittings),
                         )
-                database.bulk_upsert(
-                    session=database_client,
-                    model=database.Sitting,
-                    records=scraped_sittings.sittings,
-                )
-                database.bulk_upsert(
-                    session=database_client,
-                    model=database.SittingDay,
-                    records=scraped_sittings.sitting_days,
-                )
-                database_client.commit()
                 logger.info(
                     "term {term}: scraped {count} sittings",
                     term=term.number,
                     count=len(scraped_sittings.sittings),
                 )
 
-                # Votings
-                for sitting in scraped_sittings.sittings:
-                    scraped_votings = await scrape.scrape_votings(
-                        client=http_client,
+                sittings = sorted(
+                    scraped_sittings.sittings, key=lambda s: s.number
+                )
+                days_by_sitting: dict[str, list[database.SittingDay]] = {}
+                for day in scraped_sittings.sitting_days:
+                    days_by_sitting.setdefault(day.sitting_id, []).append(day)
+
+                # Votings & Votes
+                for sitting in sittings:
+                    await _process_sitting(
+                        http_client=http_client,
+                        database_client=database_client,
+                        limiter=limiter,
                         term=term,
                         sitting=sitting,
+                        sitting_days=days_by_sitting.get(sitting.id, []),
+                        mp_link_ids=mp_link_ids,
                         from_voting=from_voting
                         if term.number == from_term
                         and sitting.number == from_sitting
                         else None,
                     )
-                    database.bulk_upsert(
-                        session=database_client,
-                        model=database.Voting,
-                        records=scraped_votings.votings,
-                    )
-                    database.bulk_upsert(
-                        session=database_client,
-                        model=database.VotingOption,
-                        records=scraped_votings.voting_options,
-                    )
-                    database_client.commit()
-                    logger.info(
-                        "term {term}, sitting {sitting}: "
-                        "scraped {count} votings",
-                        term=term.number,
-                        sitting=sitting.number,
-                        count=len(scraped_votings.votings),
-                    )
-
-                    # Votes — scrape concurrently, single commit per sitting
-                    all_votes: list[database.VoteRecord] = []
-                    all_detail_options: list[database.VotingOption] = []
-
-                    async def _scrape_voting_votes(
-                        voting: database.Voting,
-                        term: database.Term,
-                        sitting: database.Sitting,
-                        all_votes: list[database.VoteRecord],
-                        all_detail_options: list[database.VotingOption],
-                    ) -> None:
-                        result = await scrape.scrape_votes(
-                            client=http_client,
-                            term=term,
-                            sitting=sitting,
-                            voting=voting,
-                        )
-                        all_votes.extend(result.votes)
-                        all_detail_options.extend(result.voting_options)
-                        logger.info(
-                            "term {term}, sitting {sitting}, "
-                            "voting {voting}: scraped {count} votes",
-                            term=term.number,
-                            sitting=sitting.number,
-                            voting=voting.number,
-                            count=len(result.votes),
-                        )
-
-                    async with anyio.create_task_group() as tg:
-                        for voting in scraped_votings.votings:
-                            tg.start_soon(
-                                _scrape_voting_votes,
-                                voting,
-                                term,
-                                sitting,
-                                all_votes,
-                                all_detail_options,
-                            )
-
-                    database.bulk_upsert(
-                        session=database_client,
-                        model=database.VotingOption,
-                        records=all_detail_options,
-                    )
-                    database.bulk_upsert(
-                        session=database_client,
-                        model=database.VoteRecord,
-                        records=all_votes,
-                    )
-                    database_client.commit()
 
 
 async def resume_pipeline(*, engine: Engine | None = None) -> None:
     """Resume the scraping pipeline from the last completed point.
 
     Queries the database for the most recent term, sitting, and voting,
-    then resumes the pipeline from that point.
+    then resumes the pipeline from that point. The most recent unit is
+    re-scraped (upserts make this idempotent), since it may have been
+    interrupted mid-way.
 
     Args:
         engine: SQLAlchemy engine to use. Defaults to a new engine
@@ -231,55 +300,62 @@ async def resume_pipeline(*, engine: Engine | None = None) -> None:
     if engine is None:
         engine = database.get_engine()
 
+    database.create_db_and_tables(engine=engine)
+
+    from_term: int | None = None
+    from_sitting: int | None = None
+    from_voting: int | None = None
+
     with sqlmodel.Session(engine) as database_client:
         last_term = database_client.exec(
             sqlmodel.select(database.Term).order_by(
                 sqlmodel.desc(database.Term.number)
             )
         ).first()
-        if last_term is None:
-            logger.info("no existing data found, starting fresh pipeline")
-            await pipeline(engine=engine)
-        else:
+        if last_term is not None:
+            from_term = last_term.number
             last_sitting = database_client.exec(
                 sqlmodel.select(database.Sitting)
                 .where(database.Sitting.term_id == last_term.id)
                 .order_by(sqlmodel.desc(database.Sitting.number))
             ).first()
-            if last_sitting is None:
-                logger.info(
-                    "resuming from term {term}",
-                    term=last_term.number,
-                )
-                await pipeline(engine=engine, from_term=last_term.number)
-            else:
+            if last_sitting is not None:
+                from_sitting = last_sitting.number
                 last_voting = database_client.exec(
                     sqlmodel.select(database.Voting)
                     .where(database.Voting.sitting_id == last_sitting.id)
                     .order_by(sqlmodel.desc(database.Voting.number))
                 ).first()
-                if last_voting is None:
-                    logger.info(
-                        "resuming from term {term}, sitting {sitting}",
-                        term=last_term.number,
-                        sitting=last_sitting.number,
-                    )
-                    await pipeline(
-                        engine=engine,
-                        from_term=last_term.number,
-                        from_sitting=last_sitting.number,
-                    )
-                else:
-                    logger.info(
-                        "resuming from term {term}, "
-                        "sitting {sitting}, voting {voting}",
-                        term=last_term.number,
-                        sitting=last_sitting.number,
-                        voting=last_voting.number,
-                    )
-                    await pipeline(
-                        engine=engine,
-                        from_term=last_term.number,
-                        from_sitting=last_sitting.number,
-                        from_voting=last_voting.number,
-                    )
+                if last_voting is not None:
+                    from_voting = last_voting.number
+
+    if from_term is None:
+        logger.info("no existing data found, starting fresh pipeline")
+        await pipeline(engine=engine)
+    elif from_sitting is None:
+        logger.info("resuming from term {term}", term=from_term)
+        await pipeline(engine=engine, from_term=from_term)
+    elif from_voting is None:
+        logger.info(
+            "resuming from term {term}, sitting {sitting}",
+            term=from_term,
+            sitting=from_sitting,
+        )
+        await pipeline(
+            engine=engine,
+            from_term=from_term,
+            from_sitting=from_sitting,
+        )
+    else:
+        logger.info(
+            "resuming from term {term}, sitting {sitting}, voting {voting}",
+            term=from_term,
+            sitting=from_sitting,
+            voting=from_voting,
+        )
+        await pipeline(
+            engine=engine,
+            from_term=from_term,
+            from_sitting=from_sitting,
+            from_voting=from_voting,
+        )

--- a/src/sejm_scraper/scrape.py
+++ b/src/sejm_scraper/scrape.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from itertools import groupby
 from operator import attrgetter
@@ -376,6 +377,7 @@ async def scrape_votes(
     term: database.Term,
     sitting: database.Sitting,
     voting: database.Voting,
+    mp_link_ids: Mapping[int, str] | None = None,
 ) -> ScrapedVotesResult:
     """Scrape individual MP votes for a specific voting.
 
@@ -389,6 +391,9 @@ async def scrape_votes(
         term: Term database model.
         sitting: Sitting database model.
         voting: Voting database model to scrape votes for.
+        mp_link_ids: Mapping of the MP's term-scoped id to the
+            MpToTermLink natural key, used to link each vote record
+            directly to the MP's term entry.
 
     Returns:
         Scraped vote records and voting options from the detail endpoint.
@@ -397,6 +402,7 @@ async def scrape_votes(
         ValueError: If vote data is inconsistent (VOTE_VALID without
             multiple option votes).
     """
+    link_ids: Mapping[int, str] = mp_link_ids if mp_link_ids is not None else {}
     voting_with_votes = await api_client.fetch_votes(
         client=client,
         term=term.number,
@@ -471,6 +477,7 @@ async def scrape_votes(
                         voting=voting,
                         voting_option_index=api_schemas.OptionIndex(1),
                     ),
+                    mp_to_term_link_id=link_ids.get(vote.mp_term_id),
                     mp_term_id=vote.mp_term_id,
                     vote=vote.vote,
                     party=vote.party,
@@ -494,6 +501,7 @@ async def scrape_votes(
                             voting=voting,
                             voting_option_index=voting_option,
                         ),
+                        mp_to_term_link_id=link_ids.get(vote.mp_term_id),
                         mp_term_id=vote.mp_term_id,
                         vote=inner_vote,
                         party=vote.party,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,6 +1,8 @@
 import httpx
+import pydantic
 import pytest
 import respx
+import tenacity
 
 from sejm_scraper import api_client, api_schemas
 
@@ -19,6 +21,17 @@ from .conftest import (
 @pytest.fixture(autouse=True)
 def _patch_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(api_client, "BASE_URL", MOCK_BASE_URL)
+
+
+@pytest.fixture
+def _no_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable exponential backoff so retry tests run instantly."""
+    monkeypatch.setattr(
+        api_client._fetch_list.retry, "wait", tenacity.wait_none()
+    )
+    monkeypatch.setattr(
+        api_client.fetch_votes.retry, "wait", tenacity.wait_none()
+    )
 
 
 @pytest.mark.anyio
@@ -115,3 +128,59 @@ async def test_fetch_mps() -> None:
     assert len(mps) == 1
     assert mps[0].first_name == "Andrzej"
     assert mps[0].last_name == "Adamczyk"
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_fetch_does_not_retry_client_errors() -> None:
+    route = respx.get(f"{MOCK_BASE_URL}/term").mock(
+        return_value=httpx.Response(404)
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await api_client.fetch_terms(client=client)
+
+    assert route.call_count == 1
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_fetch_does_not_retry_validation_errors() -> None:
+    route = respx.get(f"{MOCK_BASE_URL}/term").mock(
+        return_value=httpx.Response(200, json=[{"unexpected": "shape"}])
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(pydantic.ValidationError):
+            await api_client.fetch_terms(client=client)
+
+    assert route.call_count == 1
+
+
+@pytest.mark.anyio
+@respx.mock
+@pytest.mark.usefixtures("_no_retry_wait")
+async def test_fetch_retries_server_errors() -> None:
+    route = respx.get(f"{MOCK_BASE_URL}/term").mock(
+        return_value=httpx.Response(500)
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await api_client.fetch_terms(client=client)
+
+    assert route.call_count == 3
+
+
+@pytest.mark.anyio
+@respx.mock
+@pytest.mark.usefixtures("_no_retry_wait")
+async def test_fetch_retries_transport_errors() -> None:
+    route = respx.get(f"{MOCK_BASE_URL}/term10/votings/39/205").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.ConnectError):
+            await api_client.fetch_votes(
+                client=client, term=10, sitting=39, voting=205
+            )
+
+    assert route.call_count == 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from typer.testing import CliRunner
+
+from sejm_scraper import cli, pipeline
+
+runner = CliRunner()
+
+
+def test_prepare_database_creates_db_file(tmp_path: Path) -> None:
+    db_file = tmp_path / "test.duckdb"
+
+    result = runner.invoke(
+        cli.app, ["prepare-database", "--db-path", str(db_file)]
+    )
+
+    assert result.exit_code == 0
+    assert db_file.exists()
+
+
+def test_scrape_invokes_pipeline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mock_pipeline = AsyncMock()
+    monkeypatch.setattr(pipeline, "pipeline", mock_pipeline)
+    db_file = tmp_path / "test.duckdb"
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "scrape",
+            "--from-term",
+            "10",
+            "--from-sitting",
+            "39",
+            "--from-voting",
+            "205",
+            "--db-path",
+            str(db_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_pipeline.assert_called_once()
+    call_kwargs = mock_pipeline.call_args.kwargs
+    assert call_kwargs["from_term"] == 10
+    assert call_kwargs["from_sitting"] == 39
+    assert call_kwargs["from_voting"] == 205
+    assert call_kwargs["engine"] is not None
+
+
+def test_resume_invokes_resume_pipeline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mock_resume = AsyncMock()
+    monkeypatch.setattr(pipeline, "resume_pipeline", mock_resume)
+    db_file = tmp_path / "test.duckdb"
+
+    result = runner.invoke(cli.app, ["resume", "--db-path", str(db_file)])
+
+    assert result.exit_code == 0
+    mock_resume.assert_called_once()
+    assert mock_resume.call_args.kwargs["engine"] is not None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,6 +10,22 @@ if TYPE_CHECKING:
     from sqlalchemy.engine.base import Engine
 
 
+def test_json_safe_date() -> None:
+    assert database._json_safe(date(2025, 1, 15)) == "2025-01-15"
+
+
+def test_json_safe_string() -> None:
+    assert database._json_safe("hello") == "hello"
+
+
+def test_json_safe_none() -> None:
+    assert database._json_safe(None) is None
+
+
+def test_json_safe_int() -> None:
+    assert database._json_safe(42) == 42
+
+
 def test_bulk_upsert_empty_records(engine: "Engine") -> None:
     with sqlmodel.Session(engine) as session:
         database.bulk_upsert(session=session, model=database.Term, records=[])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,25 +4,10 @@ from typing import TYPE_CHECKING
 import sqlmodel
 
 from sejm_scraper import database
+from sejm_scraper.api_schemas import Vote
 
 if TYPE_CHECKING:
     from sqlalchemy.engine.base import Engine
-
-
-def test_json_safe_date() -> None:
-    assert database._json_safe(date(2025, 1, 15)) == "2025-01-15"
-
-
-def test_json_safe_string() -> None:
-    assert database._json_safe("hello") == "hello"
-
-
-def test_json_safe_none() -> None:
-    assert database._json_safe(None) is None
-
-
-def test_json_safe_int() -> None:
-    assert database._json_safe(42) == 42
 
 
 def test_bulk_upsert_empty_records(engine: "Engine") -> None:
@@ -85,6 +70,58 @@ def test_bulk_upsert_replaces_on_duplicate(engine: "Engine") -> None:
         results = session.exec(sqlmodel.select(database.Term)).all()
         assert len(results) == 1
         assert results[0].to_date == date(2027, 11, 12)
+
+
+def test_bulk_upsert_binds_enums_dates_and_nulls(
+    engine: "Engine",
+    term: database.Term,
+    sitting: database.Sitting,
+    voting: database.Voting,
+) -> None:
+    """Native parameter binding must handle StrEnum, date, and None."""
+    option = database.VotingOption(
+        id="opt1",
+        voting_id=voting.id,
+        index=1,
+        option_label=None,
+        description=None,
+        votes=0,
+    )
+    vote_record = database.VoteRecord(
+        id="vote1",
+        voting_option_id="opt1",
+        mp_to_term_link_id=None,
+        mp_term_id=1,
+        vote=Vote.YES,
+        party=None,
+    )
+    with sqlmodel.Session(engine) as session:
+        database.bulk_upsert(
+            session=session, model=database.Term, records=[term]
+        )
+        database.bulk_upsert(
+            session=session, model=database.Sitting, records=[sitting]
+        )
+        database.bulk_upsert(
+            session=session, model=database.Voting, records=[voting]
+        )
+        database.bulk_upsert(
+            session=session, model=database.VotingOption, records=[option]
+        )
+        database.bulk_upsert(
+            session=session, model=database.VoteRecord, records=[vote_record]
+        )
+        session.commit()
+
+    with sqlmodel.Session(engine) as session:
+        result = session.exec(sqlmodel.select(database.VoteRecord)).first()
+        assert result is not None
+        assert result.vote == Vote.YES
+        assert result.party is None
+        assert result.mp_to_term_link_id is None
+        stored_voting = session.exec(sqlmodel.select(database.Voting)).first()
+        assert stored_voting is not None
+        assert stored_voting.date == voting.date
 
 
 def test_create_db_and_tables_with_engine(engine: "Engine") -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -204,6 +204,45 @@ async def test_pipeline_falls_back_to_discover_sittings(
 
 
 @pytest.mark.anyio
+@pytest.mark.usefixtures("_mock_scrape")
+async def test_pipeline_passes_mp_link_ids_to_scrape_votes(
+    engine: "Engine",
+) -> None:
+    await pipeline.pipeline(engine=engine)
+
+    scrape.scrape_votes.assert_called_once()  # type: ignore[union-attr]
+    call_kwargs = scrape.scrape_votes.call_args.kwargs  # type: ignore[union-attr]
+    assert call_kwargs["mp_link_ids"] == {}
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("_mock_scrape")
+async def test_pipeline_crash_during_votes_commits_no_votings(
+    monkeypatch: pytest.MonkeyPatch,
+    engine: "Engine",
+) -> None:
+    """A failure while scraping votes must not leave the sitting's
+    votings committed — otherwise resume would treat the sitting as
+    complete and skip its votes."""
+    monkeypatch.setattr(
+        scrape,
+        "scrape_votes",
+        AsyncMock(side_effect=RuntimeError("simulated crash")),
+    )
+
+    with pytest.raises(ExceptionGroup):
+        await pipeline.pipeline(engine=engine)
+
+    with sqlmodel.Session(engine) as session:
+        # The sitting was committed when processing started...
+        sittings = session.exec(sqlmodel.select(database.Sitting)).all()
+        assert len(sittings) == 1
+        # ...but no votings: resume restarts from this sitting.
+        votings = session.exec(sqlmodel.select(database.Voting)).all()
+        assert len(votings) == 0
+
+
+@pytest.mark.anyio
 async def test_resume_pipeline_cold_start(
     monkeypatch: pytest.MonkeyPatch,
     engine: "Engine",

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -288,8 +288,32 @@ async def test_scrape_votes_single_option(
     assert len(result.votes) == 1
     assert result.votes[0].vote == api_schemas.Vote.NO
     assert result.votes[0].party == "PiS"
+    # No MP link mapping provided
+    assert result.votes[0].mp_to_term_link_id is None
     # Default voting option created
     assert len(result.voting_options) == 1
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_scrape_votes_links_mp_to_term(
+    term: database.Term,
+    sitting: database.Sitting,
+    voting: database.Voting,
+) -> None:
+    respx.get(f"{MOCK_BASE_URL}/term10/votings/39/205").mock(
+        return_value=httpx.Response(200, json=VOTE_DETAIL_RESPONSE)
+    )
+    async with httpx.AsyncClient() as client:
+        result = await scrape.scrape_votes(
+            client=client,
+            term=term,
+            sitting=sitting,
+            voting=voting,
+            mp_link_ids={1: "mp-link-key-1"},
+        )
+
+    assert result.votes[0].mp_to_term_link_id == "mp-link-key-1"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

This PR refactors the scraping pipeline to improve reliability and performance:

1. **Atomic commits per sitting**: Restructures the pipeline to commit each sitting's votings and votes atomically after all network I/O completes, ensuring the database remains consistent with the resume logic. A crash mid-sitting now leaves the sitting without votings, allowing `resume_pipeline` to restart from that sitting rather than skipping incomplete work.

2. **Bounded concurrent requests**: Adds a capacity limiter (10 concurrent requests) to vote scraping to prevent overwhelming the public Sejm API with hundreds of simultaneous requests.

3. **Improved retry logic**: Refines retry behavior to only retry transient failures (timeouts, connection errors, HTTP 429/5xx), while immediately failing on client errors (4xx) and validation errors.

4. **Better parameter binding**: Replaces JSON file-based bulk loading with native DuckDB parameter binding in `bulk_upsert`, improving type safety and eliminating file I/O overhead.

## Key Changes

- **pipeline.py**: 
  - Extracted `_scrape_voting_votes()` and `_process_sitting()` helper functions to encapsulate sitting-level processing
  - Changed commit granularity: terms committed individually as processing starts, sittings committed when processing starts, votings/votes committed atomically after all votes are scraped
  - Added `MAX_CONCURRENT_VOTE_REQUESTS` limiter using `anyio.CapacityLimiter`
  - Refactored `resume_pipeline()` to use simpler conditional logic instead of nested if-else chains

- **database.py**:
  - Modified `bulk_upsert()` to use `executemany()` with parameter binding instead of JSON file loading
  - Added `mp_to_term_link_id` field to `VoteRecord` (nullable, as some votes reference missing MPs)
  - Removed `_json_safe()` helper function (no longer needed with parameter binding)

- **api_client.py**:
  - Added `_is_retryable_error()` to distinguish transient failures from permanent errors
  - Updated `RETRY_SETTINGS` to use `retry_if_exception()` predicate, preventing retries on 4xx and validation errors

- **scrape.py**:
  - Updated `scrape_votes()` to accept optional `mp_link_ids` mapping for linking votes to MP term records

- **cli.py**:
  - Added `--db-path` option to all commands with sensible default (`sejm_scraper.duckdb`)
  - Extracted `_engine_from_path()` helper for consistent engine creation

- **Tests**:
  - Added `test_cli.py` with tests for CLI commands
  - Added tests for retry behavior (client errors, validation errors, server errors, transport errors)
  - Added test for atomic commit behavior during vote scraping failures
  - Added test for MP link ID passing to vote scraping
  - Removed `_json_safe()` unit tests (function removed)

## Notable Implementation Details

- The sitting processing order is now deterministic (sorted by sitting number) to ensure consistent resume points
- Sitting days are pre-grouped by sitting ID to avoid repeated lookups during processing
- The capacity limiter is created once and reused across all sittings in a term, providing global rate limiting
- Parameter binding in `bulk_upsert()` properly handles `StrEnum`, `date`, and `None` values without type inference issues

https://claude.ai/code/session_01UTYaNkRSmCdfACbtmp9xGx